### PR TITLE
update flow to call for user data once per request

### DIFF
--- a/assets/scss/components/_header-bar.scss
+++ b/assets/scss/components/_header-bar.scss
@@ -180,7 +180,6 @@
         &.connect-dps-common-header__toggle-open {
           background: govuk-colour("light-grey");
           color: govuk-colour("blue");
-          font-weight: 700;
 
           >span {
             &:before {
@@ -465,6 +464,7 @@
       gap: 15px 15px;
       justify-items: start;
       font-weight: bold;
+      margin-bottom: 0;
     }
   }
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,6 +16,8 @@ generic-service:
     CONTENTFUL_HOST: https://graphql.contentful.com
     CONTENTFUL_FOOTER_LINKS_ENABLED: false
     ENVIRONMENT_NAME: DEV
+    CACHE_TIMOUT: 3
+
     DPS_URL: https://digital-dev.prison.service.justice.gov.uk
     OMIC_URL: https://dev.manage-key-workers.service.justice.gov.uk
     ACTIVITIES_URL: https://activities-dev.prison.service.justice.gov.uk/activities

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,6 +16,7 @@ generic-service:
     CONTENTFUL_HOST: "https://graphql.contentful.com"
     CONTENTFUL_FOOTER_LINKS_ENABLED: false
     ENVIRONMENT_NAME: PRE-PRODUCTION
+    CACHE_TIMOUT: 600
 
     DPS_URL: https://digital-preprod.prison.service.justice.gov.uk
     OMIC_URL: https://preprod.manage-key-workers.service.justice.gov.uk

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -15,6 +15,7 @@ generic-service:
     PRISON_API_URL: "https://api.prison.service.justice.gov.uk"
     CONTENTFUL_HOST: "https://graphql.contentful.com"
     CONTENTFUL_FOOTER_LINKS_ENABLED: false
+    CACHE_TIMOUT: 600
 
     DPS_URL: https://digital.prison.service.justice.gov.uk
     OMIC_URL: https://manage-key-workers.service.justice.gov.uk

--- a/server/@types/Users.ts
+++ b/server/@types/Users.ts
@@ -27,5 +27,5 @@ export interface AuthUser {
   token: string
 }
 
-export type User = (AuthUser | TokenData) & { authSource: TokenData['auth_source']; token: string; roles: [] }
+export type User = (AuthUser | TokenData) & { authSource: TokenData['auth_source']; token: string; roles: string[] }
 export const isApiUser = (user: TokenData | AuthUser): user is TokenData => !!(user as TokenData).auth_source

--- a/server/config.ts
+++ b/server/config.ts
@@ -41,6 +41,7 @@ export default {
     port: parseInt(process.env.REDIS_PORT, 10) || 6379,
     password: process.env.REDIS_AUTH_TOKEN,
     tls_enabled: get('REDIS_TLS_ENABLED', 'false'),
+    cacheTimeout: Number(get('CACHE_TIMOUT', 600)),
   },
   session: {
     secret: get('SESSION_SECRET', 'app-insecure-default-session', requiredInProduction),

--- a/server/controllers/componentsController.test.ts
+++ b/server/controllers/componentsController.test.ts
@@ -1,5 +1,5 @@
 import { UserService } from '../services'
-import componentsController, { HeaderViewModel } from './componentsController'
+import componentsController from './componentsController'
 import ContentfulService from '../services/contentfulService'
 import config from '../config'
 import { getTokenDataMock } from '../../tests/mocks/TokenDataMock'
@@ -53,6 +53,56 @@ const defaultTokenData = getTokenDataMock()
 afterEach(() => {
   jest.clearAllMocks()
 })
+
+const defaultHeaderViewModel = {
+  activeCaseLoad: {
+    caseLoadId: 'LEI',
+    caseloadFunction: '',
+    currentlyActive: true,
+    description: 'Leeds',
+    type: '',
+  },
+  caseLoads: [
+    {
+      caseLoadId: 'LEI',
+      caseloadFunction: '',
+      currentlyActive: true,
+      description: 'Leeds',
+      type: '',
+    },
+  ],
+  changeCaseLoadLink: 'http://localhost:3001/change-caseload',
+  component: 'header',
+  ingressUrl: 'localhost',
+  isPrisonUser: true,
+  manageDetailsLink: 'http://localhost:9090/auth/account-details',
+  dpsSearchLink: 'http://localhost:3001/prisoner-search',
+  services: defaultUserData.services,
+}
+
+const defaultFooterViewModel = {
+  managedPages: [
+    {
+      href: `${config.serviceUrls.dps.url}/accessibility-statement`,
+      text: 'Accessibility',
+    },
+    {
+      href: `${config.serviceUrls.dps.url}/terms-and-conditions`,
+      text: 'Terms and conditions',
+    },
+    {
+      href: `${config.serviceUrls.dps.url}/privacy-policy`,
+      text: 'Privacy policy',
+    },
+    {
+      href: `${config.serviceUrls.dps.url}/cookies-policy`,
+      text: 'Cookies policy',
+    },
+  ],
+  isPrisonUser: true,
+  component: 'footer',
+  services: defaultUserData.services,
+}
 describe('getHeaderViewModel', () => {
   it('should return the HeaderViewModel', async () => {
     const output = await controller.getHeaderViewModel({
@@ -61,31 +111,8 @@ describe('getHeaderViewModel', () => {
       token: 'token',
       roles: [],
     })
-    expect(output).toEqual({
-      activeCaseLoad: {
-        caseLoadId: 'LEI',
-        caseloadFunction: '',
-        currentlyActive: true,
-        description: 'Leeds',
-        type: '',
-      },
-      caseLoads: [
-        {
-          caseLoadId: 'LEI',
-          caseloadFunction: '',
-          currentlyActive: true,
-          description: 'Leeds',
-          type: '',
-        },
-      ],
-      changeCaseLoadLink: 'http://localhost:3001/change-caseload',
-      component: 'header',
-      ingressUrl: 'localhost',
-      isPrisonUser: true,
-      manageDetailsLink: 'http://localhost:9090/auth/account-details',
-      dpsSearchLink: 'http://localhost:3001/prisoner-search',
-      services: defaultUserData.services,
-    })
+    expect(output).toEqual(defaultHeaderViewModel)
+    expect(userServiceMock.getUserData).toBeCalledTimes(1)
   })
 
   it('should return empty caseload information if not a nomis user', async () => {
@@ -108,59 +135,20 @@ describe('getHeaderViewModel', () => {
     })
   })
 
-  describe('caching', () => {
-    it('should return cached data if available', async () => {
-      const redisResponse: HeaderViewModel = {
-        caseLoads: [],
-        changeCaseLoadLink: 'http://localhost:3001/change-caseload',
-        component: 'header',
-        ingressUrl: 'localhost',
-        isPrisonUser: false,
-        manageDetailsLink: 'http://localhost:9090/auth/account-details',
-        dpsSearchLink: 'http://localhost:3001/prisoner-search',
-        activeCaseLoad: null,
-        services: [],
-      }
-      cacheServiceMock.getData.mockResolvedValueOnce(redisResponse)
-
-      const output = await controller.getHeaderViewModel({
-        ...defaultTokenData,
-        authSource: 'nomis',
-        token: 'token',
-        roles: [],
-      })
-
-      expect(output).toEqual(redisResponse)
+  describe('user data is passed in', () => {
+    it('should use the data passed in and not call userService', async () => {
+      config.contentfulFooterLinksEnabled = false
+      const output = await controller.getHeaderViewModel(
+        {
+          ...defaultTokenData,
+          authSource: 'nomis',
+          token: 'token',
+          roles: [],
+        },
+        defaultUserData,
+      )
+      expect(output).toEqual(defaultHeaderViewModel)
       expect(userServiceMock.getUserData).toBeCalledTimes(0)
-    })
-
-    it('should not set a cache value if caseloads count > 1', async () => {
-      userServiceMock.getUserData.mockResolvedValueOnce({
-        ...defaultUserData,
-        caseLoads: [
-          { caseloadFunction: '', caseLoadId: 'LEI', currentlyActive: true, description: 'Leeds (HMP)', type: '' },
-          { caseloadFunction: '', caseLoadId: 'MDI', currentlyActive: false, description: 'Moorland (HMP)', type: '' },
-        ],
-      })
-      await controller.getHeaderViewModel({
-        ...defaultTokenData,
-        authSource: 'nomis',
-        token: 'token',
-        roles: [],
-      })
-
-      expect(cacheServiceMock.setData).toBeCalledTimes(0)
-    })
-
-    it('should not set a cache value if caseloads count not greater than 1', async () => {
-      await controller.getHeaderViewModel({
-        ...defaultTokenData,
-        authSource: 'nomis',
-        token: 'token',
-        roles: [],
-      })
-
-      expect(cacheServiceMock.setData).toBeCalledTimes(1)
     })
   })
 })
@@ -193,84 +181,125 @@ describe('getFooterViewModel', () => {
       token: 'token',
       roles: [],
     })
+    expect(output).toEqual(defaultFooterViewModel)
+    expect(userServiceMock.getUserData).toBeCalledTimes(1)
+  })
+
+  describe('user data is passed in', () => {
+    it('should use the data passed in and not call userService', async () => {
+      config.contentfulFooterLinksEnabled = false
+      const output = await controller.getFooterViewModel(
+        {
+          ...defaultTokenData,
+          authSource: 'nomis',
+          token: 'token',
+          roles: [],
+        },
+        defaultUserData,
+      )
+      expect(output).toEqual(defaultFooterViewModel)
+      expect(userServiceMock.getUserData).toBeCalledTimes(0)
+    })
+  })
+})
+
+describe('getViewModels', () => {
+  it('should get user data if nothing in cache', async () => {
+    const output = await controller.getViewModels(['header', 'footer'], {
+      ...defaultTokenData,
+      authSource: 'nomis',
+      token: 'token',
+      roles: [],
+    })
+
+    expect(userServiceMock.getUserData).toBeCalledTimes(1)
     expect(output).toEqual({
-      managedPages: [
-        {
-          href: `${config.serviceUrls.dps.url}/accessibility-statement`,
-          text: 'Accessibility',
-        },
-        {
-          href: `${config.serviceUrls.dps.url}/terms-and-conditions`,
-          text: 'Terms and conditions',
-        },
-        {
-          href: `${config.serviceUrls.dps.url}/privacy-policy`,
-          text: 'Privacy policy',
-        },
-        {
-          href: `${config.serviceUrls.dps.url}/cookies-policy`,
-          text: 'Cookies policy',
-        },
-      ],
-      isPrisonUser: true,
-      component: 'footer',
-      services: defaultUserData.services,
+      header: defaultHeaderViewModel,
+      footer: defaultFooterViewModel,
     })
   })
 
-  describe('caching', () => {
-    it('should return cached data if available', async () => {
-      const redisResponse: HeaderViewModel = {
-        caseLoads: [],
-        changeCaseLoadLink: 'http://localhost:3001/change-caseload',
-        component: 'header',
-        ingressUrl: 'localhost',
-        isPrisonUser: false,
-        manageDetailsLink: 'http://localhost:9090/auth/account-details',
-        dpsSearchLink: 'http://localhost:3001/prisoner-search',
-        activeCaseLoad: null,
-        services: [],
-      }
-      cacheServiceMock.getData.mockResolvedValueOnce(redisResponse)
+  it('should use cache data if available', async () => {
+    cacheServiceMock.getData.mockResolvedValueOnce(defaultUserData)
 
-      const output = await controller.getFooterViewModel({
-        ...defaultTokenData,
-        authSource: 'nomis',
-        token: 'token',
-        roles: [],
-      })
-
-      expect(output).toEqual(redisResponse)
-      expect(userServiceMock.getUserData).toBeCalledTimes(0)
+    const output = await controller.getViewModels(['header', 'footer'], {
+      ...defaultTokenData,
+      authSource: 'nomis',
+      token: 'token',
+      roles: [],
     })
 
-    it('should not set a cache value if caseloads count > 1', async () => {
-      userServiceMock.getUserData.mockResolvedValueOnce({
-        ...defaultUserData,
-        caseLoads: [
-          { caseloadFunction: '', caseLoadId: 'LEI', currentlyActive: true, description: 'Leeds (HMP)', type: '' },
-          { caseloadFunction: '', caseLoadId: 'MDI', currentlyActive: false, description: 'Moorland (HMP)', type: '' },
-        ],
-      })
-      await controller.getFooterViewModel({
-        ...defaultTokenData,
-        authSource: 'nomis',
-        token: 'token',
-        roles: [],
-      })
+    expect(cacheServiceMock.setData).toBeCalledTimes(0)
+    expect(userServiceMock.getUserData).toBeCalledTimes(0)
+    expect(output).toEqual({
+      header: defaultHeaderViewModel,
+      footer: defaultFooterViewModel,
+    })
+  })
 
-      expect(cacheServiceMock.setData).toBeCalledTimes(0)
+  it('should set cache if caseloads count <= 1', async () => {
+    const userServiceResponse = {
+      ...defaultUserData,
+      caseLoads: [
+        { caseloadFunction: '', caseLoadId: 'LEI', currentlyActive: true, description: 'Leeds (HMP)', type: '' },
+      ],
+    }
+    userServiceMock.getUserData.mockResolvedValueOnce(userServiceResponse)
+
+    await controller.getViewModels(['header', 'footer'], {
+      ...defaultTokenData,
+      authSource: 'nomis',
+      token: 'token',
+      roles: [],
     })
 
-    it('should not set a cache value if caseloads count not greater than 1', async () => {
-      await controller.getFooterViewModel({
-        ...defaultTokenData,
-        authSource: 'nomis',
-        token: 'token',
-        roles: [],
-      })
+    expect(cacheServiceMock.setData).toBeCalledTimes(1)
+    expect(cacheServiceMock.setData).toBeCalledWith('TOKEN_USER_meta_data', JSON.stringify(userServiceResponse))
+  })
 
-      expect(cacheServiceMock.setData).toBeCalledTimes(1)
+  it('should not set cache if caseloads count > 1', async () => {
+    const userServiceResponse = {
+      ...defaultUserData,
+      caseLoads: [
+        { caseloadFunction: '', caseLoadId: 'LEI', currentlyActive: true, description: 'Leeds (HMP)', type: '' },
+        { caseloadFunction: '', caseLoadId: 'MDI', currentlyActive: false, description: 'Moorland (HMP)', type: '' },
+      ],
+    }
+    userServiceMock.getUserData.mockResolvedValueOnce(userServiceResponse)
+
+    await controller.getViewModels(['header', 'footer'], {
+      ...defaultTokenData,
+      authSource: 'nomis',
+      token: 'token',
+      roles: [],
+    })
+
+    expect(cacheServiceMock.setData).toBeCalledTimes(0)
+  })
+
+  it('should work for single components, header', async () => {
+    const output = await controller.getViewModels(['header'], {
+      ...defaultTokenData,
+      authSource: 'nomis',
+      token: 'token',
+      roles: [],
+    })
+
+    expect(output).toEqual({
+      header: defaultHeaderViewModel,
+    })
+  })
+
+  it('should work for single components, footer', async () => {
+    const output = await controller.getViewModels(['footer'], {
+      ...defaultTokenData,
+      authSource: 'nomis',
+      token: 'token',
+      roles: [],
+    })
+
+    expect(output).toEqual({
+      footer: defaultFooterViewModel,
     })
   })
 })

--- a/server/routes/footer.test.ts
+++ b/server/routes/footer.test.ts
@@ -44,7 +44,7 @@ beforeEach(async () => {
   prisonApi = nock(config.apis.prisonApi.url)
 
   await ensureConnected()
-  redisClient.del('TOKEN_USER_footer')
+  redisClient.del('TOKEN_USER_meta_data')
 
   app = createApp({ ...services(), contentfulService: contentfulServiceMock })
 })

--- a/server/routes/header.test.ts
+++ b/server/routes/header.test.ts
@@ -35,7 +35,7 @@ beforeEach(async () => {
   prisonApi = nock(config.apis.prisonApi.url)
 
   await ensureConnected()
-  redisClient.del('TOKEN_USER_header')
+  redisClient.del('TOKEN_USER_meta_data')
 
   app = createApp(services())
 })

--- a/server/services/cacheService.test.ts
+++ b/server/services/cacheService.test.ts
@@ -9,7 +9,7 @@ const redisClient = {
   isOpen: true,
 } as unknown as jest.Mocked<RedisClient>
 
-const service = new CacheService(redisClient)
+const service = new CacheService(redisClient, 600)
 
 describe('CacheService', () => {
   describe('setData', () => {

--- a/server/services/cacheService.ts
+++ b/server/services/cacheService.ts
@@ -2,7 +2,10 @@ import logger from '../../logger'
 import { RedisClient } from '../data/redisClient'
 
 export default class CacheService {
-  constructor(private readonly redisClient: RedisClient) {}
+  constructor(
+    private readonly redisClient: RedisClient,
+    private readonly timeout: number,
+  ) {}
 
   private async ensureConnected() {
     if (!this.redisClient.isOpen) {
@@ -13,14 +16,14 @@ export default class CacheService {
   public async setData(key: string, data: string) {
     try {
       await this.ensureConnected()
-      return await this.redisClient.set(key, data, { EX: 600 })
+      return await this.redisClient.set(key, data, { EX: this.timeout })
     } catch (error) {
       logger.error(error.stack, `Error calling redis`)
       return ''
     }
   }
 
-  public async getData(key: string) {
+  public async getData<T>(key: string): Promise<T> {
     try {
       await this.ensureConnected()
       const redisData = await this.redisClient.get(key)

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -26,7 +26,7 @@ export const services = () => {
   })
 
   const contentfulService = new ContentfulService(apolloClient)
-  const cacheService = new CacheService(createRedisClient())
+  const cacheService = new CacheService(createRedisClient(), config.redis.cacheTimeout)
 
   return {
     userService,

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -10,7 +10,7 @@ import TokenMock, { rolesForMockToken } from '../../tests/mocks/TokenMock'
 jest.mock('../data/hmppsAuthClient')
 
 const token = TokenMock
-const staffId = 12345
+const defaultTokenData = getTokenDataMock()
 
 afterEach(() => {
   jest.resetAllMocks()
@@ -82,19 +82,37 @@ describe('User service', () => {
     })
 
     it('Returns case loads', async () => {
-      const { caseLoads } = await userService.getUserData(token, staffId, rolesForMockToken)
+      const { caseLoads } = await userService.getUserData({
+        ...defaultTokenData,
+        authSource: 'nomis',
+        token: TokenMock,
+        user_id: '12345',
+        roles: rolesForMockToken,
+      })
       expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(1)
       expect(caseLoads).toEqual(expectedCaseLoads)
     })
 
     it('Returns active caseload id', async () => {
-      const { activeCaseLoad } = await userService.getUserData(token, staffId, rolesForMockToken)
+      const { activeCaseLoad } = await userService.getUserData({
+        ...defaultTokenData,
+        authSource: 'nomis',
+        token: TokenMock,
+        user_id: '12345',
+        roles: rolesForMockToken,
+      })
       expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(1)
       expect(activeCaseLoad).toEqual(expectedCaseLoads[0])
     })
 
     it('Returns services', async () => {
-      const { services } = await userService.getUserData(token, staffId, ['GLOBAL_SEARCH'])
+      const { services } = await userService.getUserData({
+        ...defaultTokenData,
+        authSource: 'nomis',
+        token: TokenMock,
+        user_id: '12345',
+        roles: ['GLOBAL_SEARCH'],
+      })
       expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(1)
       expect(services.find(service => service.heading === 'Global search')).toBeTruthy()
     })
@@ -103,7 +121,13 @@ describe('User service', () => {
       prisonApiClient.getUserCaseLoads = jest.fn(async () => {
         throw new Error('API FAIL')
       })
-      const { caseLoads } = await userService.getUserData(token, staffId, rolesForMockToken)
+      const { caseLoads } = await userService.getUserData({
+        ...defaultTokenData,
+        authSource: 'nomis',
+        token: TokenMock,
+        user_id: '12345',
+        roles: rolesForMockToken,
+      })
       expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(1)
       expect(caseLoads).toEqual([])
     })
@@ -113,10 +137,24 @@ describe('User service', () => {
         throw new Error('API FAIL')
       })
       await Promise.all(
-        [...Array(API_ERROR_LIMIT)].map(() => userService.getUserData(token, staffId, rolesForMockToken)),
+        [...Array(API_ERROR_LIMIT)].map(() =>
+          userService.getUserData({
+            ...defaultTokenData,
+            authSource: 'nomis',
+            token: TokenMock,
+            user_id: '12345',
+            roles: rolesForMockToken,
+          }),
+        ),
       )
 
-      const { caseLoads } = await userService.getUserData(token, staffId, rolesForMockToken)
+      const { caseLoads } = await userService.getUserData({
+        ...defaultTokenData,
+        authSource: 'nomis',
+        token: TokenMock,
+        user_id: '12345',
+        roles: rolesForMockToken,
+      })
       expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(API_ERROR_LIMIT)
       expect(caseLoads).toEqual([])
     })
@@ -127,12 +165,26 @@ describe('User service', () => {
         throw new Error('API FAIL')
       })
       await Promise.all(
-        [...Array(API_ERROR_LIMIT)].map(() => userService.getUserData(token, staffId, rolesForMockToken)),
+        [...Array(API_ERROR_LIMIT)].map(() =>
+          userService.getUserData({
+            ...defaultTokenData,
+            authSource: 'nomis',
+            token: TokenMock,
+            user_id: '12345',
+            roles: rolesForMockToken,
+          }),
+        ),
       )
 
       jest.advanceTimersByTime(API_COOL_OFF_MINUTES * 60000)
 
-      await userService.getUserData(token, staffId, rolesForMockToken)
+      await userService.getUserData({
+        ...defaultTokenData,
+        authSource: 'nomis',
+        token: TokenMock,
+        user_id: '12345',
+        roles: rolesForMockToken,
+      })
       expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(API_ERROR_LIMIT + 1)
 
       jest.useRealTimers()


### PR DESCRIPTION
- Route methods all call getViewModels passing in component/s required and user object
- getViewModels checks cache for user object, gets if needed, caches and sends to the view model builders requested
 