### PR TITLE
CDPS-514 Uprate autoscaling on the MFE component

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -8,8 +8,8 @@ generic-service:
 
   autoscaling:
     enabled: true
-    minReplicas: 4
-    maxReplicas: 8
+    minReplicas: 8
+    maxReplicas: 16
     targetCPUUtilizationPercentage: 1600
 
   env:


### PR DESCRIPTION
to give the service leeway, uprate the HPA rom 4 -> 8 to 8 -> 16 pods,using the scaling settings previously set. Only applies to Prod.