### PR TITLE
cache for mutiple caseload users. collect new data if caseload has ch…

### DIFF
--- a/server/controllers/componentsController.ts
+++ b/server/controllers/componentsController.ts
@@ -102,9 +102,12 @@ export default ({
     const username = apiUser ? user.user_name : user.username
 
     const cachedResponse = await cacheService.getData<UserData>(`${username}_meta_data`)
+    const userData = await userService.getUserData(user, cachedResponse)
 
-    const userData = cachedResponse ?? (await userService.getUserData(user))
-    if (!cachedResponse && userData.caseLoads.length === 1) {
+    if (
+      userData.caseLoads.length > 0 &&
+      (!cachedResponse || cachedResponse.activeCaseLoad.caseLoadId !== userData.activeCaseLoad.caseLoadId)
+    ) {
       await cacheService.setData(`${username}_meta_data`, JSON.stringify(userData))
     }
 

--- a/server/routes/header.test.ts
+++ b/server/routes/header.test.ts
@@ -197,52 +197,6 @@ describe('GET /header', () => {
             expect($(`a[href="${config.serviceUrls.dps.url}/change-caseload"]`).length).toEqual(0)
           })
       })
-
-      it('should not use cached caseloads the second time if 2 active caseloads', async () => {
-        prisonApi.get('/api/users/me/caseLoads').reply(200, [
-          {
-            caseLoadId: 'LEI',
-            description: 'Leeds',
-            type: '',
-            caseloadFunction: '',
-            currentlyActive: true,
-          },
-          {
-            caseLoadId: 'DEE',
-            description: 'Deerbolt',
-            type: '',
-            caseloadFunction: '',
-            currentlyActive: false,
-          },
-        ])
-        prisonApi.get('/api/users/me/caseLoads').reply(200, [
-          {
-            caseLoadId: 'LEI',
-            description: 'Leeds',
-            type: '',
-            caseloadFunction: '',
-            currentlyActive: true,
-          },
-        ])
-
-        // second set of calls will be made as no caching 2 active caseloads, add more nock responses
-        prisonApi.get('/api/users/me/locations').reply(200, [])
-        prisonApi.get('/api/staff/11111/LEI/roles/KW').reply(200, 'true')
-
-        // make first call with 2 active caseloads
-        await request(app).get('/header').set('x-user-token', 'token').expect(200).expect('Content-Type', /json/)
-
-        return request(app)
-          .get('/header')
-          .set('x-user-token', 'token')
-          .expect(200)
-          .expect('Content-Type', /json/)
-          .expect(res => {
-            const $ = cheerio.load(JSON.parse(res.text).html)
-            // using the value from second request
-            expect($(`a[href="${config.serviceUrls.dps.url}/change-caseload"]`).length).toEqual(0)
-          })
-      })
     })
   })
 

--- a/server/services/cacheService.ts
+++ b/server/services/cacheService.ts
@@ -23,7 +23,7 @@ export default class CacheService {
     }
   }
 
-  public async getData<T>(key: string): Promise<T> {
+  public async getData<T>(key: string): Promise<T | null> {
     try {
       await this.ensureConnected()
       const redisData = await this.redisClient.get(key)

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -7,6 +7,8 @@ import { getTokenDataMock } from '../../tests/mocks/TokenDataMock'
 import authUserMock from '../../tests/mocks/AuthUserMock'
 import TokenMock, { rolesForMockToken } from '../../tests/mocks/TokenMock'
 import CacheService from './cacheService'
+import { User } from '../@types/Users'
+import { UserData } from '../interfaces/UserData'
 
 jest.mock('../data/hmppsAuthClient')
 
@@ -89,116 +91,174 @@ describe('User service', () => {
       )
     })
 
-    it('Returns case loads', async () => {
-      const { caseLoads } = await userService.getUserData({
+    describe('with no cached data', () => {
+      it('Returns case loads', async () => {
+        const { caseLoads } = await userService.getUserData({
+          ...defaultTokenData,
+          authSource: 'nomis',
+          token: TokenMock,
+          user_id: '12345',
+          roles: rolesForMockToken,
+        })
+        expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(1)
+        expect(caseLoads).toEqual(expectedCaseLoads)
+      })
+
+      it('Returns active caseload id', async () => {
+        const { activeCaseLoad } = await userService.getUserData({
+          ...defaultTokenData,
+          authSource: 'nomis',
+          token: TokenMock,
+          user_id: '12345',
+          roles: rolesForMockToken,
+        })
+        expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(1)
+        expect(activeCaseLoad).toEqual(expectedCaseLoads[0])
+      })
+
+      it('Returns services', async () => {
+        const { services } = await userService.getUserData({
+          ...defaultTokenData,
+          authSource: 'nomis',
+          token: TokenMock,
+          user_id: '12345',
+          roles: ['GLOBAL_SEARCH'],
+        })
+        expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(1)
+        expect(services.find(service => service.heading === 'Global search')).toBeTruthy()
+      })
+
+      it('Returns empty list if api fails', async () => {
+        prisonApiClient.getUserCaseLoads = jest.fn(async () => {
+          throw new Error('API FAIL')
+        })
+        const { caseLoads } = await userService.getUserData({
+          ...defaultTokenData,
+          authSource: 'nomis',
+          token: TokenMock,
+          user_id: '12345',
+          roles: rolesForMockToken,
+        })
+        expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(1)
+        expect(caseLoads).toEqual([])
+      })
+
+      it(`Sets circuit breaker if api fails ${API_ERROR_LIMIT} times`, async () => {
+        jest.useFakeTimers()
+        prisonApiClient.getUserCaseLoads = jest.fn(() => {
+          throw new Error('API FAIL')
+        })
+        await Promise.all(
+          [...Array(API_ERROR_LIMIT)].map(() =>
+            userService.getUserData({
+              ...defaultTokenData,
+              authSource: 'nomis',
+              token: TokenMock,
+              user_id: '12345',
+              roles: rolesForMockToken,
+            }),
+          ),
+        )
+
+        const { caseLoads } = await userService.getUserData({
+          ...defaultTokenData,
+          authSource: 'nomis',
+          token: TokenMock,
+          user_id: '12345',
+          roles: rolesForMockToken,
+        })
+        expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(API_ERROR_LIMIT)
+        expect(caseLoads).toEqual([])
+
+        jest.runAllTimers()
+      })
+
+      it(`Unsets circuit breaker after ${API_COOL_OFF_MINUTES} minutes`, async () => {
+        jest.useFakeTimers()
+        prisonApiClient.getUserCaseLoads = jest.fn(async () => {
+          throw new Error('API FAIL')
+        })
+        await Promise.all(
+          [...Array(API_ERROR_LIMIT)].map(() =>
+            userService.getUserData({
+              ...defaultTokenData,
+              authSource: 'nomis',
+              token: TokenMock,
+              user_id: '12345',
+              roles: rolesForMockToken,
+            }),
+          ),
+        )
+
+        jest.advanceTimersByTime(API_COOL_OFF_MINUTES * 60000)
+
+        await userService.getUserData({
+          ...defaultTokenData,
+          authSource: 'nomis',
+          token: TokenMock,
+          user_id: '12345',
+          roles: rolesForMockToken,
+        })
+        expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(API_ERROR_LIMIT + 1)
+
+        jest.useRealTimers()
+      })
+    })
+
+    describe('with cached data', () => {
+      const defaultUser: User = {
         ...defaultTokenData,
         authSource: 'nomis',
         token: TokenMock,
         user_id: '12345',
         roles: rolesForMockToken,
+      }
+      it('returns cached data if number of caseloads is 1', async () => {
+        const cachedData: UserData = {
+          caseLoads: [{ caseloadFunction: '', caseLoadId: '1', currentlyActive: true, description: '', type: '' }],
+          activeCaseLoad: { caseloadFunction: '', caseLoadId: '1', currentlyActive: true, description: '', type: '' },
+          services: [],
+        }
+        const output = await userService.getUserData(defaultUser, cachedData)
+        expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(0)
+        expect(prisonApiClient.getUserLocations).toBeCalledTimes(0)
+        expect(prisonApiClient.getIsKeyworker).toBeCalledTimes(0)
+        expect(output).toEqual(cachedData)
       })
-      expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(1)
-      expect(caseLoads).toEqual(expectedCaseLoads)
-    })
 
-    it('Returns active caseload id', async () => {
-      const { activeCaseLoad } = await userService.getUserData({
-        ...defaultTokenData,
-        authSource: 'nomis',
-        token: TokenMock,
-        user_id: '12345',
-        roles: rolesForMockToken,
+      it('returns cached data if number of active caseload is unchanged', async () => {
+        const cachedData: UserData = {
+          caseLoads: [
+            expectedCaseLoads[0],
+            { caseloadFunction: '', caseLoadId: '2', currentlyActive: true, description: '', type: '' },
+          ],
+          activeCaseLoad: expectedCaseLoads[0],
+          services: [],
+        }
+        const output = await userService.getUserData(defaultUser, cachedData)
+        expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(1)
+        expect(prisonApiClient.getUserLocations).toBeCalledTimes(0)
+        expect(prisonApiClient.getIsKeyworker).toBeCalledTimes(0)
+        expect(output).toEqual(cachedData)
       })
-      expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(1)
-      expect(activeCaseLoad).toEqual(expectedCaseLoads[0])
-    })
 
-    it('Returns services', async () => {
-      const { services } = await userService.getUserData({
-        ...defaultTokenData,
-        authSource: 'nomis',
-        token: TokenMock,
-        user_id: '12345',
-        roles: ['GLOBAL_SEARCH'],
+      it('gets new data if active caseload has changed', async () => {
+        const cachedData: UserData = {
+          caseLoads: [
+            expectedCaseLoads[0],
+            { caseloadFunction: '', caseLoadId: '2', currentlyActive: true, description: '', type: '' },
+          ],
+          activeCaseLoad: { caseloadFunction: '', caseLoadId: '2', currentlyActive: true, description: '', type: '' },
+          services: [],
+        }
+        const output = await userService.getUserData(defaultUser, cachedData)
+        expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(1)
+        expect(prisonApiClient.getUserLocations).toBeCalledTimes(1)
+        expect(prisonApiClient.getIsKeyworker).toBeCalledTimes(1)
+        expect(output.caseLoads).toEqual(expectedCaseLoads)
+        expect(output.activeCaseLoad).toEqual(expectedCaseLoads[0])
+        expect(output.services.find(service => service.heading === 'Global search')).toBeTruthy()
       })
-      expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(1)
-      expect(services.find(service => service.heading === 'Global search')).toBeTruthy()
-    })
-
-    it('Returns empty list if api fails', async () => {
-      prisonApiClient.getUserCaseLoads = jest.fn(async () => {
-        throw new Error('API FAIL')
-      })
-      const { caseLoads } = await userService.getUserData({
-        ...defaultTokenData,
-        authSource: 'nomis',
-        token: TokenMock,
-        user_id: '12345',
-        roles: rolesForMockToken,
-      })
-      expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(1)
-      expect(caseLoads).toEqual([])
-    })
-
-    it(`Sets circuit breaker if api fails ${API_ERROR_LIMIT} times`, async () => {
-      jest.useFakeTimers()
-      prisonApiClient.getUserCaseLoads = jest.fn(() => {
-        throw new Error('API FAIL')
-      })
-      await Promise.all(
-        [...Array(API_ERROR_LIMIT)].map(() =>
-          userService.getUserData({
-            ...defaultTokenData,
-            authSource: 'nomis',
-            token: TokenMock,
-            user_id: '12345',
-            roles: rolesForMockToken,
-          }),
-        ),
-      )
-
-      const { caseLoads } = await userService.getUserData({
-        ...defaultTokenData,
-        authSource: 'nomis',
-        token: TokenMock,
-        user_id: '12345',
-        roles: rolesForMockToken,
-      })
-      expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(API_ERROR_LIMIT)
-      expect(caseLoads).toEqual([])
-
-      jest.runAllTimers()
-    })
-
-    it(`Unsets circuit breaker after ${API_COOL_OFF_MINUTES} minutes`, async () => {
-      jest.useFakeTimers()
-      prisonApiClient.getUserCaseLoads = jest.fn(async () => {
-        throw new Error('API FAIL')
-      })
-      await Promise.all(
-        [...Array(API_ERROR_LIMIT)].map(() =>
-          userService.getUserData({
-            ...defaultTokenData,
-            authSource: 'nomis',
-            token: TokenMock,
-            user_id: '12345',
-            roles: rolesForMockToken,
-          }),
-        ),
-      )
-
-      jest.advanceTimersByTime(API_COOL_OFF_MINUTES * 60000)
-
-      await userService.getUserData({
-        ...defaultTokenData,
-        authSource: 'nomis',
-        token: TokenMock,
-        user_id: '12345',
-        roles: rolesForMockToken,
-      })
-      expect(prisonApiClient.getUserCaseLoads).toBeCalledTimes(API_ERROR_LIMIT + 1)
-
-      jest.useRealTimers()
     })
   })
 })


### PR DESCRIPTION
To reduce calls to the problem /roles api.

1. Cache response for all users
2. Single caseload users -> return cached data
3. Multi caseload users -> check if caseload has changed, if not return cached data
4. caseload changed -> get new data