### PR TITLE
collect activeAgencies information from activities service

### DIFF
--- a/helm_deploy/hmpps-micro-frontend-components/templates/services-cronjob.yaml
+++ b/helm_deploy/hmpps-micro-frontend-components/templates/services-cronjob.yaml
@@ -18,6 +18,8 @@ spec:
               env:
               - name: ENVIRONMENT_NAME
                 value: "{{ index .Values "generic-service" "env" "ENVIRONMENT_NAME" }}"
+              - name: ACTIVITIES_URL
+                value: "{{ index .Values "generic-service" "env" "ACTIVITIES_URL" }}"
               - name: REDIS_HOST
                 valueFrom:
                   secretKeyRef:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,8 +24,8 @@ generic-service:
     DPS_URL: https://digital-dev.prison.service.justice.gov.uk
     NEW_DPS_URL: https://dps-dev.prison.service.justice.gov.uk
     OMIC_URL: https://dev.manage-key-workers.service.justice.gov.uk
-    ACTIVITIES_URL: https://activities-dev.prison.service.justice.gov.uk/activities
-    APPOINTMENTS_URL: https://activities-dev.prison.service.justice.gov.uk/appointments
+    ACTIVITIES_URL: https://activities-dev.prison.service.justice.gov.uk
+    APPOINTMENTS_URL: https://activities-dev.prison.service.justice.gov.uk
     CHECK_MY_DIARY_URL: https://check-my-diary-dev.prison.service.justice.gov.uk?fromDPS=true
     INCENTIVES_URL: https://incentives-ui-dev.hmpps.service.justice.gov.uk
     USE_OF_FORCE_URL: https://dev.use-of-force.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -22,8 +22,8 @@ generic-service:
     DPS_URL: https://digital-preprod.prison.service.justice.gov.uk
     NEW_DPS_URL: https://dps-preprod.prison.service.justice.gov.uk
     OMIC_URL: https://preprod.manage-key-workers.service.justice.gov.uk
-    ACTIVITIES_URL: https://activities-preprod.prison.service.justice.gov.uk/activities
-    APPOINTMENTS_URL: https://activities-preprod.prison.service.justice.gov.uk/appointments
+    ACTIVITIES_URL: https://activities-preprod.prison.service.justice.gov.uk
+    APPOINTMENTS_URL: https://activities-preprod.prison.service.justice.gov.uk
     CHECK_MY_DIARY_URL: https://check-my-diary-preprod.prison.service.justice.gov.uk?fromDPS=true
     INCENTIVES_URL: https://incentives-ui-preprod.hmpps.service.justice.gov.uk
     USE_OF_FORCE_URL: https://preprod.use-of-force.service.justice.gov.uk

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -27,8 +27,8 @@ generic-service:
     DPS_URL: https://digital.prison.service.justice.gov.uk
     NEW_DPS_URL: https://dps.prison.service.justice.gov.uk
     OMIC_URL: https://manage-key-workers.service.justice.gov.uk
-    ACTIVITIES_URL: https://activities.prison.service.justice.gov.uk/activities
-    APPOINTMENTS_URL: https://activities.prison.service.justice.gov.uk/appointments
+    ACTIVITIES_URL: https://activities.prison.service.justice.gov.uk
+    APPOINTMENTS_URL: https://activities.prison.service.justice.gov.uk
     CHECK_MY_DIARY_URL: https://checkmydiary.service.justice.gov.uk?fromDPS=true
     INCENTIVES_URL: https://incentives-ui.hmpps.service.justice.gov.uk
     USE_OF_FORCE_URL: https://use-of-force.service.justice.gov.uk

--- a/scripts/getReleaseStatus.js
+++ b/scripts/getReleaseStatus.js
@@ -10,14 +10,15 @@ const endpoints = [
       DEV: 'https://manage-adjudications-api-dev.hmpps.service.justice.gov.uk/info',
     },
   },
+  { application: 'activities', urlEnv: 'ACTIVITIES_URL' },
 ]
 
 function getApplicationInfo(url) {
-  return superagent.get(url).set('Accept', 'application/json').retry(2).timeout(3000)
+  return superagent.get(url).set('Accept', 'application/json').retry(2)
 }
 
-async function cacheResponses(body) {
-  const client = await redis
+function getRedisClient() {
+  return redis
     .createClient({
       url: `rediss://${process.env.REDIS_HOST || 'localhost'}:${process.env.REDIS_PORT || 6379}`,
       password: process.env.REDIS_AUTH_TOKEN,
@@ -27,7 +28,10 @@ async function cacheResponses(body) {
       throw new Error(err)
     })
     .connect()
+}
 
+async function cacheResponses(body) {
+  const client = await getRedisClient()
   const resp = await client.set('applicationInfo', JSON.stringify(body))
   await client.disconnect()
 
@@ -35,24 +39,55 @@ async function cacheResponses(body) {
   return resp
 }
 
+async function getStoredData() {
+  const client = await getRedisClient()
+  const responseString = await client.get('applicationInfo')
+  await client.disconnect()
+
+  return JSON.parse(responseString)
+}
+
 const getData = async () => {
-  const responses = await Promise.all(
-    endpoints.map(app => getApplicationInfo(app.infoUrl[process.env.ENVIRONMENT_NAME])),
+  const storedData = await getStoredData()
+
+  const responses = await Promise.allSettled(
+    endpoints.map(app =>
+      getApplicationInfo(app.urlEnv ? `${process.env[app.urlEnv]}/info` : app.infoUrl[process.env.ENVIRONMENT_NAME]),
+    ),
   )
 
-  const body = responses
+  const newData = responses
     .map(response => {
+      if (response.status !== 'fulfilled') {
+        console.log(`Failed to get application info`, response.reason)
+        return undefined
+      }
+      const { body, request } = response.value
       const applicationName = endpoints.find(
-        app => response.request.url === app.infoUrl[process.env.ENVIRONMENT_NAME],
+        app =>
+          request?.url === (app.urlEnv ? `${process.env[app.urlEnv]}/info` : app.infoUrl[process.env.ENVIRONMENT_NAME]),
       )?.application
       if (!applicationName) return undefined
 
       return {
         app: applicationName,
-        activeAgencies: response.body.activeAgencies,
+        activeAgencies: body.activeAgencies,
       }
     })
     .filter(Boolean)
+
+  // use new data if we have it for app, use stored data if we don't have it.
+  // append any new apps not in stored data
+  // if we have no stored data use new data for all
+  const body = storedData
+    ? storedData
+        .map(stored => {
+          const newApp = newData.find(newApp => newApp.app === stored.app)
+          if (!newApp) return stored
+          return newApp
+        })
+        .concat(newData.filter(newApp => !storedData.find(stored => stored.app === newApp.app)))
+    : newData
 
   return cacheResponses(body)
 }

--- a/scripts/getReleaseStatus.test.js
+++ b/scripts/getReleaseStatus.test.js
@@ -4,6 +4,7 @@ const { mockRedisClientMock } = require('redis')
 jest.mock('redis', () => {
   const mockRedisClientMock = {
     set: jest.fn().mockResolvedValue('OK'),
+    get: jest.fn().mockResolvedValue(null),
     disconnect: jest.fn().mockResolvedValue('OK'),
   }
 
@@ -25,38 +26,131 @@ describe('Get release status script', () => {
     nock.cleanAll()
   })
 
-  it('should get application info', async () => {
+  it('should get application info for all apps', async () => {
     const { mockRedisClientMock } = require('redis')
     const apiResponse = { some: 'stuff', activeAgencies: ['agency1', 'agency2'] }
     nock('https://manage-adjudications-api-dev.hmpps.service.justice.gov.uk').get('/info').reply(200, apiResponse)
+    nock('https://activities-test.hmpps.service.justice.gov.uk').get('/info').reply(200, apiResponse)
 
     const result = await getData()
 
     expect(mockRedisClientMock.set).toHaveBeenCalledWith(
       'applicationInfo',
-      JSON.stringify([{ app: 'adjudications', activeAgencies: ['agency1', 'agency2'] }]),
+      JSON.stringify([
+        { app: 'adjudications', activeAgencies: ['agency1', 'agency2'] },
+        { app: 'activities', activeAgencies: ['agency1', 'agency2'] },
+      ]),
     )
     expect(result).toEqual('OK')
   })
 
-  it('should throw if api errors', async () => {
+  it('should store the data it gets if others fail', async () => {
     const { mockRedisClientMock } = require('redis')
+    const apiResponse = { some: 'stuff', activeAgencies: ['agency1', 'agency2'] }
     nock('https://manage-adjudications-api-dev.hmpps.service.justice.gov.uk').get('/info').reply(404)
+    nock('https://activities-test.hmpps.service.justice.gov.uk').get('/info').reply(200, apiResponse)
 
-    await expect(getData()).rejects.toThrow('Not Found')
+    await getData()
 
-    expect(mockRedisClientMock.set).toHaveBeenCalledTimes(0)
+    expect(mockRedisClientMock.set).toHaveBeenCalledWith(
+      'applicationInfo',
+      JSON.stringify([{ app: 'activities', activeAgencies: ['agency1', 'agency2'] }]),
+    )
   })
 
   it('should not fail if it cant find the data in response', async () => {
     const { mockRedisClientMock } = require('redis')
-    const apiResponse = { some: 'stuff' }
-    nock('https://manage-adjudications-api-dev.hmpps.service.justice.gov.uk').get('/info').reply(200, apiResponse)
+    nock('https://manage-adjudications-api-dev.hmpps.service.justice.gov.uk').get('/info').reply(200, { some: 'stuff' })
+    nock('https://activities-test.hmpps.service.justice.gov.uk')
+      .get('/info')
+      .reply(200, { some: 'stuff', activeAgencies: ['agency1', 'agency2'] })
 
     const result = await getData()
     expect(mockRedisClientMock.set).toHaveBeenCalledWith(
       'applicationInfo',
-      JSON.stringify([{ app: 'adjudications', activeAgencies: undefined }]),
+      JSON.stringify([
+        { app: 'adjudications', activeAgencies: undefined },
+        { app: 'activities', activeAgencies: ['agency1', 'agency2'] },
+      ]),
     )
+  })
+
+  describe('when redis is available', () => {
+    it('should use the stored data if it exists and no new data', async () => {
+      const { mockRedisClientMock } = require('redis')
+      nock('https://manage-adjudications-api-dev.hmpps.service.justice.gov.uk').get('/info').replyWithError('ERROR')
+      nock('https://activities-test.hmpps.service.justice.gov.uk').get('/info').replyWithError('ERROR')
+      const storedData = [{ app: 'adjudications', activeAgencies: ['agency1', 'agency2'] }]
+      mockRedisClientMock.get.mockResolvedValue(JSON.stringify(storedData))
+
+      await getData()
+
+      expect(mockRedisClientMock.set).toHaveBeenCalledWith('applicationInfo', JSON.stringify(storedData))
+    })
+
+    it('should use the stored data for app if it exists and no new data', async () => {
+      const { mockRedisClientMock } = require('redis')
+      const storedData = [
+        { app: 'adjudications', activeAgencies: ['agency1', 'agency2'] },
+        { app: 'activities', activeAgencies: ['agency1', 'agency2'] },
+      ]
+
+      nock('https://manage-adjudications-api-dev.hmpps.service.justice.gov.uk').get('/info').replyWithError('ERROR')
+      nock('https://activities-test.hmpps.service.justice.gov.uk')
+        .get('/info')
+        .reply(200, { some: 'stuff', activeAgencies: ['agency1', 'agency2'] })
+      mockRedisClientMock.get.mockResolvedValue(JSON.stringify(storedData))
+
+      await getData()
+
+      expect(mockRedisClientMock.set).toHaveBeenCalledWith(
+        'applicationInfo',
+        JSON.stringify([
+          { app: 'adjudications', activeAgencies: ['agency1', 'agency2'] },
+          { app: 'activities', activeAgencies: ['agency1', 'agency2'] },
+        ]),
+      )
+    })
+
+    it('should use new app data if it does not exist on stored data', async () => {
+      const { mockRedisClientMock } = require('redis')
+      const storedData = [{ app: 'adjudications', activeAgencies: ['agency1', 'agency2'] }]
+
+      nock('https://manage-adjudications-api-dev.hmpps.service.justice.gov.uk').get('/info').replyWithError('ERROR')
+      nock('https://activities-test.hmpps.service.justice.gov.uk')
+        .get('/info')
+        .reply(200, { some: 'stuff', activeAgencies: ['agency1', 'agency2'] })
+      mockRedisClientMock.get.mockResolvedValue(JSON.stringify(storedData))
+
+      await getData()
+
+      expect(mockRedisClientMock.set).toHaveBeenCalledWith(
+        'applicationInfo',
+        JSON.stringify([...storedData, { app: 'activities', activeAgencies: ['agency1', 'agency2'] }]),
+      )
+    })
+
+    it('should replace the stored data for app with new data', async () => {
+      const { mockRedisClientMock } = require('redis')
+      const storedData = [{ app: 'adjudications', activeAgencies: ['agency1', 'agency2'] }]
+
+      nock('https://manage-adjudications-api-dev.hmpps.service.justice.gov.uk')
+        .get('/info')
+        .reply(200, { activeAgencies: ['agency3', 'agency4'] })
+      nock('https://activities-test.hmpps.service.justice.gov.uk')
+        .get('/info')
+        .reply(200, { some: 'stuff', activeAgencies: ['agency1', 'agency2'] })
+      mockRedisClientMock.get.mockResolvedValue(JSON.stringify(storedData))
+
+      await getData()
+
+      expect(mockRedisClientMock.set).toHaveBeenCalledWith(
+        'applicationInfo',
+        JSON.stringify([
+          { app: 'adjudications', activeAgencies: ['agency3', 'agency4'] },
+          { app: 'activities', activeAgencies: ['agency1', 'agency2'] },
+        ]),
+      )
+    })
   })
 })

--- a/server/@types/activeAgencies.ts
+++ b/server/@types/activeAgencies.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line no-shadow
 export enum ServiceName {
   ADJUDICATION = 'adjudications',
+  ACTIVITIES = 'activities',
 }
 
 export interface ServiceActiveAgencies {

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -276,14 +276,14 @@ export default (
       heading: 'Allocate people, unlock and attend',
       description:
         'Create and edit activities. Log applications and manage waitlists. Allocate people and edit allocations. Print unlock lists and record attendance.',
-      href: config.serviceUrls.activities.url,
+      href: `${config.serviceUrls.activities.url}/activities`,
       enabled: () => config.serviceUrls.activities.enabledPrisons.split(',').includes(activeCaseLoadId),
     },
     {
       id: 'appointments',
       heading: 'Schedule and edit appointments',
       description: 'Create and manage appointments. Print movement slips.',
-      href: config.serviceUrls.appointments.url,
+      href: `${config.serviceUrls.appointments.url}/appointments`,
       enabled: () => config.serviceUrls.appointments.enabledPrisons.split(',').includes(activeCaseLoadId),
     },
     {

--- a/tests/setEnvVars.js
+++ b/tests/setEnvVars.js
@@ -1,1 +1,2 @@
 process.env.ENVIRONMENT_NAME = 'DEV'
+process.env.ACTIVITIES_URL = 'https://activities-test.hmpps.service.justice.gov.uk'


### PR DESCRIPTION
Just the script potion

strategy:

- make requests to all endpoints
- replace list in cache for each app with new results

on individual api failure:

- continue with others
- replace list in cache for apps that have been successful
- use list from cache for apps that have been unsuccessful