### PR TITLE
RR-537 use the PLP team version of the prisoner list page (PLP)

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -49,7 +49,7 @@ generic-service:
     HISTORICAL_PRISONER_APPLICATION_URL: https://hpa-stage.hmpps.dsd.io
     GET_SOMEONE_READY_FOR_WORK_URL: https://get-ready-for-work-dev.hmpps.service.justice.gov.uk
     MANAGE_OFFENCES_URL: https://manage-offences-dev.hmpps.service.justice.gov.uk
-    LEARNING_AND_WORK_PROGRESS_URL: https://ciag-induction-dev.hmpps.service.justice.gov.uk
+    LEARNING_AND_WORK_PROGRESS_URL: https://learning-and-work-progress-dev.hmpps.service.justice.gov.uk
     PREPARE_SOMEONE_FOR_RELEASE_URL: https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk
 
     # Feature


### PR DESCRIPTION
## Description

We have now switched over to using the PLP version of the Prisoner List page (from the CIAG version). This change updates the URL for the DPS Homepage Learning and work progress service tile for the `dev` environments. Further changes will be done for other environments once tested.

https://dsdmoj.atlassian.net/browse/RR-537 