### PR TITLE
RR-537 use the PLP team version of the prisoner list page (PLP)

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -47,7 +47,7 @@ generic-service:
     HISTORICAL_PRISONER_APPLICATION_URL: https://hpa-preprod.service.hmpps.dsd.io
     GET_SOMEONE_READY_FOR_WORK_URL: https://get-ready-for-work-preprod.hmpps.service.justice.gov.uk
     MANAGE_OFFENCES_URL: https://manage-offences-preprod.hmpps.service.justice.gov.uk
-    LEARNING_AND_WORK_PROGRESS_URL: https://ciag-induction-preprod.hmpps.service.justice.gov.uk
+    LEARNING_AND_WORK_PROGRESS_URL: https://learning-and-work-progress-preprod.hmpps.service.justice.gov.uk
     PREPARE_SOMEONE_FOR_RELEASE_URL: https://resettlement-passport-ui-preprod.hmpps.service.justice.gov.uk
 
     # Feature

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -52,7 +52,7 @@ generic-service:
     HISTORICAL_PRISONER_APPLICATION_URL: https://hpa.service.hmpps.dsd.io
     GET_SOMEONE_READY_FOR_WORK_URL: https://get-ready-for-work.hmpps.service.justice.gov.uk
     MANAGE_OFFENCES_URL: https://manage-offences.hmpps.service.justice.gov.uk
-    LEARNING_AND_WORK_PROGRESS_URL: https://ciag-induction.hmpps.service.justice.gov.uk
+    LEARNING_AND_WORK_PROGRESS_URL: https://learning-and-work-progress.hmpps.service.justice.gov.uk
     PREPARE_SOMEONE_FOR_RELEASE_URL: https://resettlement-passport-ui.hmpps.service.justice.gov.uk
 
     # Feature


### PR DESCRIPTION
## Description

We have now switched over to using the PLP version of the Prisoner List page (from the CIAG version). This change updates the URL for the DPS Homepage Learning and work progress service tile for the `preprod` and `prod` environments.

https://dsdmoj.atlassian.net/browse/RR-537 

Tested on `dev` here: https://github.com/ministryofjustice/hmpps-micro-frontend-components/pull/145