### PR TITLE
SDIT-1384 StaffResource - catch access error

### DIFF
--- a/server/data/prisonApiClient.ts
+++ b/server/data/prisonApiClient.ts
@@ -14,7 +14,15 @@ export default class PrisonApiClient {
   }
 
   async getIsKeyworker(activeCaseloadId: string, staffId: number): Promise<boolean> {
-    return this.get<boolean>({ path: `/api/staff/${staffId}/${activeCaseloadId}/roles/KW` })
+    try {
+      return this.get<boolean>({ path: `/api/staff/${staffId}/${activeCaseloadId}/roles/KW` })
+    } catch (error) {
+      if (error.status === 403) {
+        // can happen for CADM (central admin) users
+        return false
+      }
+      throw error
+    }
   }
 
   async getUserLocations(): Promise<Location[]> {

--- a/server/routes/header.test.ts
+++ b/server/routes/header.test.ts
@@ -99,6 +99,19 @@ describe('GET /header', () => {
           expect($('a[href="/sign-out"]').text()).toEqual('Sign out')
         })
     })
+
+    it('should render despite roles api failure', () => {
+      prisonApi.get('/api/staff/11111/LEI/roles/KW').reply(403, '')
+      return request(app)
+        .get('/header')
+        .set('x-user-token', 'token')
+        .expect(200)
+        .expect('Content-Type', /json/)
+        .expect(res => {
+          const $ = cheerio.load(JSON.parse(res.text).html)
+          expect($('a[href="/sign-out"]').text()).toEqual('Sign out')
+        })
+    })
   })
 
   describe('case load switcher', () => {


### PR DESCRIPTION
Now that the prison-api endpoint has been protected with a role, some scenarios will fail