### PR TITLE
update expanded state labels remove aria label from user menu toggle

### DIFF
--- a/assets/js/header.js
+++ b/assets/js/header.js
@@ -16,11 +16,14 @@ function initHeader() {
   if (searchToggle) {
     hideFallbackLinks()
     searchToggle.removeAttribute('hidden')
-    searchToggle.setAttribute('aria-expanded', 'false')
     userToggle.removeAttribute('hidden')
-    userToggle.setAttribute('aria-expanded', 'false')
     servicesToggle.removeAttribute('hidden')
-    servicesToggle.setAttribute('aria-expanded', 'false')
+
+    closeTabs([
+      [searchToggle, searchMenu],
+      [userToggle, userMenu],
+      [servicesToggle, servicesMenu],
+    ])
 
     searchToggle.addEventListener('click', function (event) {
       closeTabs([
@@ -54,12 +57,12 @@ function initHeader() {
 }
 
 function closeTabs(tabTuples) {
-  tabTuples.forEach(([tab, menu]) => {
+  tabTuples.forEach(([toggle, menu]) => {
     menu.setAttribute('hidden', 'hidden')
-    tab.classList.remove(tabOpenClass)
-    tab.parentElement.classList.remove('item-open')
-    tab.setAttribute('aria-expanded', 'false')
-    tab.setAttribute('aria-label', tab.dataset.textForShow)
+    toggle.classList.remove(tabOpenClass)
+    toggle.parentElement.classList.remove('item-open')
+    toggle.setAttribute('aria-expanded', 'false')
+    if (toggle.dataset.textForShow) toggle.setAttribute('aria-label', toggle.dataset.textForShow)
   })
 }
 
@@ -73,7 +76,7 @@ function toggleMenu(toggle, menu) {
     toggle.classList.add(tabOpenClass)
     toggle.parentElement.classList.add('item-open')
     toggle.setAttribute('aria-expanded', 'true')
-    toggle.setAttribute('aria-label', toggle.dataset.textForHide)
+    if (toggle.dataset.textForHide) toggle.setAttribute('aria-label', toggle.dataset.textForHide)
   }
 }
 

--- a/server/views/partials/dpsHeader.njk
+++ b/server/views/partials/dpsHeader.njk
@@ -80,10 +80,11 @@
 
             {# USER MENU #}
             <div class="connect-dps-common-header__navigation__item">
-              <button class="connect-dps-common-header__menu-toggle connect-dps-common-header__user-menu-toggle" aria-controls="connect-dps-common-header-user-menu" aria-expanded="false" aria-label="Hide user menu" data-text-for-show="Show user menu" data-text-for-hide="Hide user manu" type="button" hidden='hidden'>
+              <button class="connect-dps-common-header__menu-toggle connect-dps-common-header__user-menu-toggle" aria-controls="connect-dps-common-header-user-menu" aria-expanded="false" type="button" hidden='hidden'>
                   <span>
                     {{ userSvg | safe }}
                     <span data-qa="connect-dps-common-header-user-name">{{ user.displayName | initialiseName }}</span>
+                    <span class="govuk-visually-hidden">Account menu</span>
                   </span>
               </button>
               <ul id="connect-dps-common-header-user-menu" class="govuk-list connect-dps-common-header__user-menu" hidden="hidden">
@@ -104,7 +105,7 @@
 
             {# SERVICES MENU #}
             <div class="connect-dps-common-header__navigation__item">
-              <button data-qa="connect-dps-common-service-menu-toggle" class="connect-dps-common-header__menu-toggle connect-dps-common-header__services-menu-toggle" aria-controls="connect-dps-common-header-services-menu" aria-expanded="false" aria-label="Hide services menu" data-text-for-show="Show services menu" data-text-for-hide="Hide services manu" type="button" hidden='hidden'>
+              <button data-qa="connect-dps-common-service-menu-toggle" class="connect-dps-common-header__menu-toggle connect-dps-common-header__services-menu-toggle" aria-controls="connect-dps-common-header-services-menu" aria-expanded="false" data-text-for-show="Show services menu" data-text-for-hide="Hide services menu" type="button" hidden='hidden'>
                   <span>
                     <span class='govuk-!-font-size-19 govuk-!-font-weight-bold'>Menu</span>
                   </span>
@@ -123,7 +124,7 @@
 
             {#  SEARCH #}
             <div class="connect-dps-common-header__navigation__item">
-              <button data-qa="connect-dps-common-search-toggle" class="connect-dps-common-header__search-menu-toggle" aria-controls="connect-dps-common-header-search-menu" aria-expanded="true" aria-label="Hide search menu" data-text-for-show="Show search menu" data-text-for-hide="Hide search manu" hidden="hidden" type="button">
+              <button data-qa="connect-dps-common-search-toggle" class="connect-dps-common-header__search-menu-toggle" aria-controls="connect-dps-common-header-search-menu" aria-expanded="true" data-text-for-show="Show search menu" data-text-for-hide="Hide search menu" hidden="hidden" type="button">
                 <span class="govuk-visually-hidden"> Search for prisoner</span>
                 {{ searchSvg() | safe }}
                 <span aria-hidden="true" class="connect-dps-common-header__search-menu-toggle__close-icon" focusable="false"> × </span>


### PR DESCRIPTION
To tackle issues here https://uv3030-activities-and-appointments-management.uservisionaccessibility.co.uk/menus-announced-incorrectly-by-screen-readers-medium.html

- Fix 'manu' typo
- Allow JS to update all the aria labels to closed state at initiation 
- Remove aria labels from user menu and used hidden text to allow the reader to read the name
- Don't set the aria labels in the JS if the data attributes not there