### PR TITLE
MAP-794 set tile url for CSC in prod

### DIFF
--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -55,7 +55,7 @@ generic-service:
     LEARNING_AND_WORK_PROGRESS_URL: https://learning-and-work-progress.hmpps.service.justice.gov.uk
     PREPARE_SOMEONE_FOR_RELEASE_URL: https://resettlement-passport-ui.hmpps.service.justice.gov.uk
     CAS2_URL: https://short-term-accommodation-cas-2.hmpps.service.justice.gov.uk
-    CHANGE_SOMEONES_CELL_URL: https://digital.prison.service.justice.gov.uk/change-someones-cell
+    CHANGE_SOMEONES_CELL_URL: https://change-someones-cell.prison.service.justice.gov.uk
     ACCREDITED_PROGRAMMES_URL: https://accredited-programmes.hmpps.service.justice.gov.uk
 
     # Feature


### PR DESCRIPTION
This will enable a Prod user to navigate to the new CSC app via the tile