### PR TITLE
Rr-1094: Update logic for Learning and work progress tile

### DIFF
--- a/integration_tests/integration_tests/e2e/footer.cy.ts
+++ b/integration_tests/integration_tests/e2e/footer.cy.ts
@@ -15,7 +15,7 @@ context('Footer', () => {
     cy.signIn()
     const indexPage = Page.verifyOnPage(IndexPage)
 
-    indexPage.footer.services.list().should('have.length', 7)
+    indexPage.footer.services.list().should('have.length', 8)
   })
 
   it('Links should be displayed', () => {

--- a/integration_tests/integration_tests/e2e/header.cy.ts
+++ b/integration_tests/integration_tests/e2e/header.cy.ts
@@ -38,7 +38,7 @@ context('Header', () => {
 
     indexPage.header.services.toggle().click()
     indexPage.header.services.menu().should('be.visible')
-    indexPage.header.services.list().should('have.length', 7)
+    indexPage.header.services.list().should('have.length', 8)
 
     indexPage.header.services.toggle().click()
     indexPage.header.services.menu().should('not.be.visible')

--- a/server/routes/footer.test.ts
+++ b/server/routes/footer.test.ts
@@ -168,7 +168,7 @@ describe('GET /footer', () => {
         .expect(res => {
           const $ = cheerio.load(JSON.parse(res.text).html)
           const serviceLinks = $('.connect-dps-common-footer__services-menu').find('a')
-          expect(serviceLinks.length).toEqual(5)
+          expect(serviceLinks.length).toEqual(6)
         })
     })
   })

--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -494,19 +494,19 @@ describe('getServicesForUser', () => {
 
   describe('Learning and work progress', () => {
     test.each`
-      roles                                                           | activeServices                                                                  | visible
-      ${[Role.EducationWorkPlanEditor, Role.EducationWorkPlanViewer]} | ${[{ app: 'learningAndWorkProgress' as ServiceName, activeAgencies: ['LEI'] }]} | ${true}
-      ${[Role.EducationWorkPlanEditor, Role.EducationWorkPlanViewer]} | ${[{ app: 'learningAndWorkProgress' as ServiceName, activeAgencies: ['***'] }]} | ${true}
-      ${[Role.EducationWorkPlanEditor, Role.EducationWorkPlanViewer]} | ${[{ app: 'learningAndWorkProgress' as ServiceName, activeAgencies: ['MDI'] }]} | ${false}
-      ${[Role.EducationWorkPlanEditor]}                               | ${[{ app: 'learningAndWorkProgress' as ServiceName, activeAgencies: ['LEI'] }]} | ${true}
-      ${[Role.EducationWorkPlanEditor]}                               | ${[{ app: 'learningAndWorkProgress' as ServiceName, activeAgencies: ['MDI'] }]} | ${false}
-      ${[Role.EducationWorkPlanViewer]}                               | ${[{ app: 'learningAndWorkProgress' as ServiceName, activeAgencies: ['LEI'] }]} | ${true}
-      ${[Role.EducationWorkPlanViewer]}                               | ${[{ app: 'learningAndWorkProgress' as ServiceName, activeAgencies: ['MDI'] }]} | ${false}
-      ${[]}                                                           | ${[{ app: 'learningAndWorkProgress' as ServiceName, activeAgencies: ['LEI'] }]} | ${false}
-    `('user with roles: $roles, can see: $visible', ({ roles, activeServices, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], activeServices)
-      expect(!!output.find(service => service.heading === 'Learning and work progress')).toEqual(visible)
-    })
+      activeServices                                                                  | activeCaseLoadId | visible
+      ${[{ app: 'learningAndWorkProgress' as ServiceName, activeAgencies: ['LEI'] }]} | ${'LEI'}         | ${true}
+      ${[{ app: 'learningAndWorkProgress' as ServiceName, activeAgencies: ['***'] }]} | ${'LEI'}         | ${true}
+      ${[{ app: 'learningAndWorkProgress' as ServiceName, activeAgencies: ['MDI'] }]} | ${'MDI'}         | ${true}
+      ${[{ app: 'learningAndWorkProgress' as ServiceName, activeAgencies: ['LEI'] }]} | ${'MDI'}         | ${false}
+      ${[]}                                                                           | ${'LEI'}         | ${false}
+    `(
+      'user with activeCaseLoadId: $activeCaseLoadId, can see: $visible',
+      ({ activeServices, activeCaseLoadId, visible }) => {
+        const output = getServicesForUser([], false, activeCaseLoadId, 12345, [], activeServices)
+        expect(!!output.find(service => service.heading === 'Learning and work progress')).toEqual(visible)
+      },
+    )
   })
 
   describe('Prepare someone for release', () => {

--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -498,8 +498,8 @@ describe('getServicesForUser', () => {
       ${[{ app: 'learningAndWorkProgress' as ServiceName, activeAgencies: ['LEI'] }]} | ${'LEI'}         | ${true}
       ${[{ app: 'learningAndWorkProgress' as ServiceName, activeAgencies: ['***'] }]} | ${'LEI'}         | ${true}
       ${[{ app: 'learningAndWorkProgress' as ServiceName, activeAgencies: ['MDI'] }]} | ${'MDI'}         | ${true}
-      ${[{ app: 'learningAndWorkProgress' as ServiceName, activeAgencies: ['LEI'] }]} | ${'MDI'}         | ${false}
-      ${[]}                                                                           | ${'LEI'}         | ${false}
+      ${[{ app: 'learningAndWorkProgress' as ServiceName, activeAgencies: ['LEI'] }]} | ${'MDI'}         | ${true}
+      ${[]}                                                                           | ${'LEI'}         | ${true}
     `(
       'user with activeCaseLoadId: $activeCaseLoadId, can see: $visible',
       ({ activeServices, activeCaseLoadId, visible }) => {

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -388,8 +388,7 @@ export default (
       description: 'View and manage learning and work history, support needs, goals and progress.',
       href: config.serviceUrls.learningAndWorkProgress.url,
       navEnabled: true,
-      enabled: () =>
-        isActiveInEstablishment(activeCaseLoadId, ServiceName.LEARNING_AND_WORK_PROGRESS, activeServices, false),
+      enabled: () => true,
     },
     {
       id: 'prepare-someone-for-release',

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -389,7 +389,6 @@ export default (
       href: config.serviceUrls.learningAndWorkProgress.url,
       navEnabled: true,
       enabled: () =>
-        userHasRoles([Role.EducationWorkPlanEditor, Role.EducationWorkPlanViewer], roles) &&
         isActiveInEstablishment(activeCaseLoadId, ServiceName.LEARNING_AND_WORK_PROGRESS, activeServices, false),
     },
     {

--- a/tests/mocks/hmppsUserMock.ts
+++ b/tests/mocks/hmppsUserMock.ts
@@ -12,6 +12,13 @@ export const servicesMock: Service[] = [
     navEnabled: true,
   },
   {
+    id: 'learning-and-work-progress',
+    heading: 'Learning and work progress',
+    description: 'View and manage learning and work history, support needs, goals and progress.',
+    href: 'https://learning-and-work-progress-dev.hmpps.service.justice.gov.uk',
+    navEnabled: true,
+  },
+  {
     id: 'key-worker-allocations',
     heading: 'My key worker allocation',
     description: 'View your key worker cases.',


### PR DESCRIPTION
Currently the DPS tile is controlled by some logic that says the prison must be enabled AND the user must have one of our service roles.

This PR removes this logic, making the tile visible to all users in all prisons.

---

### Important
This PR relies on the PLP service itself being made read-only to all users in `prod`.
This PR should not be merged until the PLP team have confirmed that it is safe to do so.