### PR TITLE
MAP-1881: Change establishment roll link in dev/preprod to point at n…

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -64,6 +64,7 @@ generic-service:
     CSIP_UI_URL: https://csip-dev.hmpps.service.justice.gov.uk
     INCIDENT_REPORTING_URL: https://incident-reporting-dev.hmpps.service.justice.gov.uk
     CASE_NOTES_API_URL: https://dev.offender-case-notes.service.justice.gov.uk
+    ESTABLISHMENT_ROLL_URL: https://prison-roll-count-dev.hmpps.service.justice.gov.uk
 
     # Feature
     ACTIVITIES_ENABLED_PRISONS: "LEI,RSI,LPI"
@@ -75,7 +76,6 @@ generic-service:
     FEATURE_SERVICES_STORE_ENABLED: true
     ACCREDITED_PROGRAMMES_ENABLED: true
     REPORTING_ENABLED_PRISONS: "***"
-    ESTABLISHMENT_ROLL_EXCLUDED: ""
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-micro-frontend-components-non-prod

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -61,6 +61,7 @@ generic-service:
     CSIP_UI_URL: https://csip-preprod.hmpps.service.justice.gov.uk
     INCIDENT_REPORTING_URL: https://incident-reporting-preprod.hmpps.service.justice.gov.uk
     CASE_NOTES_API_URL: https://preprod.offender-case-notes.service.justice.gov.uk
+    ESTABLISHMENT_ROLL_URL: https://prison-roll-count-preprod.hmpps.service.justice.gov.uk
 
     # Feature
     ACTIVITIES_ENABLED_PRISONS: "RSI,LPI"
@@ -72,7 +73,6 @@ generic-service:
     FEATURE_SERVICES_STORE_ENABLED: true
     ACCREDITED_PROGRAMMES_ENABLED: true
     REPORTING_ENABLED_PRISONS: "EXI,BNI,LYI,LYI"
-    ESTABLISHMENT_ROLL_EXCLUDED: ""
 
   allowlist:
     sscl-blackpool: 31.121.5.27/32

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -66,6 +66,7 @@ generic-service:
     CSIP_UI_URL: https://csip.hmpps.service.justice.gov.uk
     INCIDENT_REPORTING_URL: https://incident-reporting.hmpps.service.justice.gov.uk
     CASE_NOTES_API_URL: https://offender-case-notes.service.justice.gov.uk
+    ESTABLISHMENT_ROLL_URL: https://dps.prison.service.justice.gov.uk/establishment-roll
 
     # Feature
     ACTIVITIES_ENABLED_PRISONS: "RSI,LPI"
@@ -77,7 +78,6 @@ generic-service:
     FEATURE_SERVICES_STORE_ENABLED: true
     ACCREDITED_PROGRAMMES_ENABLED: true
     REPORTING_ENABLED_PRISONS: "EXI,BNI,LYI,LYI"
-    ESTABLISHMENT_ROLL_EXCLUDED: ""
 
   allowlist:
     sscl-blackpool: 31.121.5.27/32

--- a/server/config.ts
+++ b/server/config.ts
@@ -221,13 +221,13 @@ export default {
     incidentReporting: {
       url: get('INCIDENT_REPORTING_URL', 'http://localhost:3001', requiredInProduction),
     },
+    establishmentRoll: {
+      url: get('ESTABLISHMENT_ROLL_URL', 'http://localhost:3001', requiredInProduction),
+    },
   },
   features: {
     servicesStore: {
       enabled: get('FEATURE_SERVICES_STORE_ENABLED', 'false', requiredInProduction) === 'true',
-    },
-    establishmentRoll: {
-      excluded: get('ESTABLISHMENT_ROLL_EXCLUDED', ''),
     },
   },
 }

--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -47,11 +47,7 @@ jest.mock('../../config', () => ({
     residentialLocations: { url: 'url' },
     incidentReporting: { url: 'url' },
     caseNotesApi: { url: 'url' },
-  },
-  features: {
-    establishmentRoll: {
-      excluded: 'MDI,LEI',
-    },
+    establishmentRoll: { url: 'url' },
   },
 }))
 
@@ -170,15 +166,13 @@ describe('getServicesForUser', () => {
 
   describe('Establishment roll check', () => {
     test.each`
-      locations | visible  | activeCaseLoadId | href
-      ${[]}     | ${false} | ${'MDI'}         | ${undefined}
-      ${[{}]}   | ${true}  | ${'MDI'}         | ${'http://old-dps.com/establishment-roll'}
-      ${[{}]}   | ${true}  | ${'DNI'}         | ${'http://new-dps.com/establishment-roll'}
-    `('user with locations: $locations.length, can see: $visible', ({ locations, visible, activeCaseLoadId, href }) => {
+      locations | visible  | activeCaseLoadId
+      ${[]}     | ${false} | ${'MDI'}
+      ${[{}]}   | ${true}  | ${'MDI'}
+      ${[{}]}   | ${true}  | ${'DNI'}
+    `('user with locations: $locations.length, can see: $visible', ({ locations, visible, activeCaseLoadId }) => {
       const output = getServicesForUser([], false, activeCaseLoadId, 12345, locations, null)
-      const serviceData = output.find(service => service.heading === 'Establishment roll check')
-      expect(!!serviceData).toEqual(visible)
-      expect(serviceData?.href).toEqual(href)
+      expect(!!output.find(service => service.heading === 'Establishment roll check')).toEqual(visible)
     })
   })
 

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -150,7 +150,7 @@ export default (
       id: 'establishment-roll',
       heading: 'Establishment roll check',
       description: 'View the roll broken down by residential unit and see who is arriving and leaving.',
-      href: `${config.features.establishmentRoll.excluded.split(',').includes(activeCaseLoadId) ? config.serviceUrls.dps.url : config.serviceUrls.newDps.url}/establishment-roll`,
+      href: config.serviceUrls.establishmentRoll.url,
       navEnabled: true,
       enabled: () => locations?.length > 0,
     },


### PR DESCRIPTION
### Establishment roll is [moving to a standalone app](https://dsdmoj.atlassian.net/jira/software/c/projects/MAP/boards/1354?selectedIssue=MAP-1734). 

This PR points the establishment roll link in dev/preprod envs to the new standalone service.

Prod environment will remain pointing at establishment roll on DPS for now. 

PR also removes the feature flag ESTABLISHMENT_ROLL_EXCLUDED.