### PR TITLE
Add Alerts UI to service list

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -57,6 +57,7 @@ generic-service:
     CHANGE_SOMEONES_CELL_URL: https://change-someones-cell-dev.prison.service.justice.gov.uk
     ACCREDITED_PROGRAMMES_URL: https://accredited-programmes-dev.hmpps.service.justice.gov.uk
     ALERTS_API_URL: https://alerts-api-dev.hmpps.service.justice.gov.uk
+    ALERTS_UI_URL: https://alerts-ui-dev.hmpps.service.justice.gov.uk
     REPORTING_URL: https://digital-prison-reporting-mi-ui-dev.hmpps.service.justice.gov.uk
     RESIDENTIAL_LOCATIONS_URL: https://locations-inside-prison-dev.hmpps.service.justice.gov.uk
     RESIDENTIAL_LOCATIONS_API_URL: https://locations-inside-prison-api-dev.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -54,6 +54,7 @@ generic-service:
     CHANGE_SOMEONES_CELL_URL: https://change-someones-cell-preprod.prison.service.justice.gov.uk
     ACCREDITED_PROGRAMMES_URL: https://accredited-programmes-preprod.hmpps.service.justice.gov.uk
     ALERTS_API_URL: https://alerts-api-preprod.hmpps.service.justice.gov.uk
+    ALERTS_UI_URL: https://alerts-ui-preprod.hmpps.service.justice.gov.uk
     REPORTING_URL: https://digital-prison-reporting-mi-ui-preprod.hmpps.service.justice.gov.uk
     RESIDENTIAL_LOCATIONS_URL: https://locations-inside-prison-preprod.hmpps.service.justice.gov.uk
     RESIDENTIAL_LOCATIONS_API_URL: https://locations-inside-prison-api-preprod.hmpps.service.justice.gov.uk

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -59,6 +59,7 @@ generic-service:
     CHANGE_SOMEONES_CELL_URL: https://change-someones-cell.prison.service.justice.gov.uk
     ACCREDITED_PROGRAMMES_URL: https://accredited-programmes.hmpps.service.justice.gov.uk
     ALERTS_API_URL: https://alerts-api.hmpps.service.justice.gov.uk
+    ALERTS_UI_URL: https://alerts-ui.hmpps.service.justice.gov.uk
     REPORTING_URL: https://digital-prison-reporting-mi-ui.hmpps.service.justice.gov.uk
     RESIDENTIAL_LOCATIONS_URL: https://locations-inside-prison.hmpps.service.justice.gov.uk
     RESIDENTIAL_LOCATIONS_API_URL: https://locations-inside-prison-api.hmpps.service.justice.gov.uk

--- a/server/config.ts
+++ b/server/config.ts
@@ -200,6 +200,9 @@ export default {
     alerts: {
       url: get('ALERTS_API_URL', 'http://localhost:3001', requiredInProduction),
     },
+    alertsUI: {
+      url: get('ALERTS_UI_URL', 'http://localhost:3001', requiredInProduction),
+    },
     csipApi: {
       url: get('CSIP_API_URL', 'http://localhost:3001', requiredInProduction),
     },

--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -42,6 +42,7 @@ jest.mock('../../config', () => ({
     changeSomeonesCell: { url: 'url' },
     accreditedProgrammes: { url: 'url' },
     alerts: { url: 'url' },
+    alertsUI: { url: 'url' },
     csipUI: { url: 'url' },
     reporting: { url: 'url', enabledPrisons: 'AAA' },
     residentialLocations: { url: 'url' },
@@ -592,7 +593,7 @@ describe('getServicesForUser', () => {
     })
   })
 
-  describe('Alerts', () => {
+  describe('Alerts API', () => {
     test.each`
       roles | activeServices                                  | visible
       ${[]} | ${[{ app: 'alerts', activeAgencies: ['LEI'] }]} | ${true}
@@ -600,6 +601,23 @@ describe('getServicesForUser', () => {
     `('user with roles: $roles, can see: $visible', ({ roles, visible, activeServices }) => {
       const output = getServicesForUser(roles, false, 'LEI', 12345, [], activeServices)
       expect(!!output.find(service => service.heading === 'Alerts')).toEqual(visible)
+    })
+  })
+
+  describe('Alerts UI', () => {
+    test.each`
+      roles                                                             | activeServices                                  | visible  | description
+      ${['ALERTS_REFERENCE_DATA_MANAGER']}                              | ${[{ app: 'alerts', activeAgencies: ['LEI'] }]} | ${true}  | ${'Edit alerts and alert types and make different alerts active and inactive.'}
+      ${['BULK_PRISON_ESTATE_ALERTS']}                                  | ${[{ app: 'alerts', activeAgencies: ['LEI'] }]} | ${true}  | ${'Upload alerts in bulk.'}
+      ${['ALERTS_REFERENCE_DATA_MANAGER', 'BULK_PRISON_ESTATE_ALERTS']} | ${[{ app: 'alerts', activeAgencies: ['LEI'] }]} | ${true}  | ${'Edit alerts and alert types, make different alerts active and inactive, and upload alerts in bulk.'}
+      ${[]}                                                             | ${[{ app: 'alerts', activeAgencies: ['LEI'] }]} | ${false} | ${''}
+    `('user with roles: $roles, can see: $visible', ({ roles, visible, activeServices, description }) => {
+      const output = getServicesForUser(roles, false, 'LEI', 12345, [], activeServices)
+      const alertsUIService = output.find(service => service.heading === 'Manage prisoner alerts')
+      expect(!!alertsUIService).toEqual(visible)
+      if (description) {
+        expect(alertsUIService.description).toEqual(description)
+      }
     })
   })
 

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -427,6 +427,25 @@ export default (
       enabled: () => isActiveInEstablishment(activeCaseLoadId, ServiceName.ALERTS, activeServices, false),
     },
     {
+      id: 'alertsUI',
+      heading: 'Manage prisoner alerts',
+      description: [
+        '',
+        'Upload alerts in bulk.',
+        'Edit alerts and alert types and make different alerts active and inactive.',
+        'Edit alerts and alert types, make different alerts active and inactive, and upload alerts in bulk.',
+      ][
+        +userHasRoles([Role.BulkPrisonEstateAlerts], roles) +
+          +userHasRoles([Role.AlertsReferenceDataManager], roles) * 2
+      ],
+      href: config.serviceUrls.alertsUI.url,
+      navEnabled: true,
+      enabled: () =>
+        (userHasRoles([Role.BulkPrisonEstateAlerts], roles) ||
+          userHasRoles([Role.AlertsReferenceDataManager], roles)) &&
+        isActiveInEstablishment(activeCaseLoadId, ServiceName.ALERTS, activeServices, false),
+    },
+    {
       id: 'caseNotesApi',
       heading: 'Case Notes API',
       description: 'Case Notes API Service',

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -34,6 +34,17 @@ function isActiveInEstablishmentWithLegacyFallback(
 
   return isActiveInEstablishment(activeCaseLoadId, service, activeServices, legacyFallbackEnabled)
 }
+
+function getAlertsUiServiceDescription(roles: string[]): string {
+  const canUploadBulkAlerts: boolean = userHasRoles([Role.BulkPrisonEstateAlerts], roles)
+  const canEditReferenceData: boolean = userHasRoles([Role.AlertsReferenceDataManager], roles)
+  if (canUploadBulkAlerts && canEditReferenceData)
+    return 'Edit alerts and alert types, make different alerts active and inactive, and upload alerts in bulk.'
+  if (canUploadBulkAlerts) return 'Upload alerts in bulk.'
+  if (canEditReferenceData) return 'Edit alerts and alert types and make different alerts active and inactive.'
+  return ''
+}
+
 export default (
   roles: string[],
   isKeyworker: boolean,
@@ -429,15 +440,7 @@ export default (
     {
       id: 'alertsUI',
       heading: 'Manage prisoner alerts',
-      description: [
-        '',
-        'Upload alerts in bulk.',
-        'Edit alerts and alert types and make different alerts active and inactive.',
-        'Edit alerts and alert types, make different alerts active and inactive, and upload alerts in bulk.',
-      ][
-        +userHasRoles([Role.BulkPrisonEstateAlerts], roles) +
-          +userHasRoles([Role.AlertsReferenceDataManager], roles) * 2
-      ],
+      description: getAlertsUiServiceDescription(roles),
       href: config.serviceUrls.alertsUI.url,
       navEnabled: true,
       enabled: () =>

--- a/server/services/utils/roles.ts
+++ b/server/services/utils/roles.ts
@@ -81,6 +81,8 @@ export enum Role {
   IncidentReportingApprove = 'INCIDENT_REPORTS__APPROVE',
   ManagePrisonerApps = 'MANAGING_PRISONER_APPS',
   DietAndAllergiesReport = 'DIET_AND_FOOD_ALLERGIES_REPORT',
+  AlertsReferenceDataManager = 'ALERTS_REFERENCE_DATA_MANAGER',
+  BulkPrisonEstateAlerts = 'BULK_PRISON_ESTATE_ALERTS',
 }
 export const userHasRoles = (rolesToCheck: string[], userRoles: string[]): boolean => {
   return rolesToCheck.some(role => userRoles.includes(role))


### PR DESCRIPTION
- Add Alerts UI to the list of services if the user has either `ROLE_ALERTS_REFERENCE_DATA_MANAGER` or `ROLE_BULK_PRISON_ESTATE_ALERTS` central admin roles. Three users currently have these.
- Description text is conditional based on which of the two roles the user possesses.