### PR TITLE
Add cemo tile

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -67,6 +67,7 @@ generic-service:
     CASE_NOTES_API_URL: https://dev.offender-case-notes.service.justice.gov.uk
     MANAGE_APPLICATIONS_URL: https://managing-prisoner-apps-staff-ui-dev.hmpps.service.justice.gov.uk
     ESTABLISHMENT_ROLL_URL: https://prison-roll-count-dev.hmpps.service.justice.gov.uk
+    CEMO_URL: https://hmpps-electronic-monitoring-create-an-order-dev.hmpps.service.justice.gov.uk
 
     # Feature
     ACTIVITIES_ENABLED_PRISONS: "LEI,RSI,LPI"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -64,6 +64,7 @@ generic-service:
     CASE_NOTES_API_URL: https://preprod.offender-case-notes.service.justice.gov.uk
     MANAGE_APPLICATIONS_URL: https://managing-prisoner-apps-staff-ui-preprod.hmpps.service.justice.gov.uk
     ESTABLISHMENT_ROLL_URL: https://prison-roll-count-preprod.hmpps.service.justice.gov.uk
+    CEMO_URL: https://hmpps-electronic-monitoring-create-an-order-preprod.hmpps.service.justice.gov.uk
 
     # Feature
     ACTIVITIES_ENABLED_PRISONS: "RSI,LPI"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -69,6 +69,7 @@ generic-service:
     CASE_NOTES_API_URL: https://offender-case-notes.service.justice.gov.uk
     MANAGE_APPLICATIONS_URL: https://managing-prisoner-apps-staff-ui.hmpps.service.justice.gov.uk
     ESTABLISHMENT_ROLL_URL: https://prison-roll-count.hmpps.service.justice.gov.uk
+    CEMO_URL: https://hmpps-electronic-monitoring-create-an-order.hmpps.service.justice.gov.uk
 
     # Feature
     ACTIVITIES_ENABLED_PRISONS: "RSI,LPI"

--- a/server/config.ts
+++ b/server/config.ts
@@ -228,6 +228,9 @@ export default {
     establishmentRoll: {
       url: get('ESTABLISHMENT_ROLL_URL', 'http://localhost:3001', requiredInProduction),
     },
+    createAnEMOrder: {
+      url: get('CEMO_URL', 'http://localhost:3001', requiredInProduction),
+    },
   },
   features: {
     servicesStore: {

--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -760,4 +760,16 @@ describe('getServicesForUser', () => {
       expect(!!output.find(service => service.heading === 'Case Notes API')).toEqual(visible)
     })
   })
+
+  describe('Create an electronic monitoring order', () => {
+    test.each([
+      [[], false],
+      [[Role.CreateAnEMOrder], true],
+    ])('user with roles $1, can see $2', (roles, visible) => {
+      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      expect(
+        !!output.find(service => service.heading === 'Apply, change or end an Electronic Monitoring Order (EMO)'),
+      ).toEqual(visible)
+    })
+  })
 })

--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -765,7 +765,7 @@ describe('getServicesForUser', () => {
     test.each([
       [[], false],
       [[Role.CreateAnEMOrder], true],
-    ])('user with roles $1, can see $2', (roles, visible) => {
+    ])('user with roles %s, can see: %s', (roles, visible) => {
       const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
       expect(
         output.some(service => service.heading === 'Apply, change or end an Electronic Monitoring Order (EMO)'),

--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -49,6 +49,7 @@ jest.mock('../../config', () => ({
     caseNotesApi: { url: 'url' },
     establishmentRoll: { url: 'url' },
     manageApplications: { url: 'url' },
+    createAnEMOrder: { url: 'url' },
   },
 }))
 

--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -763,10 +763,12 @@ describe('getServicesForUser', () => {
 
   describe('Create an electronic monitoring order', () => {
     test.each([
-      [[], false],
-      [[Role.CreateAnEMOrder], true],
-    ])('user with roles %s, can see: %s', (roles, visible) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      [[], 'LEI', false],
+      [[Role.CreateAnEMOrder], 'LEI', false],
+      [[Role.CreateAnEMOrder], 'DNI', true],
+      [[Role.CreateAnEMOrder], 'WEI', true],
+    ])('user with roles %s, can see: %s', (roles, activeCaseLoadId, visible) => {
+      const output = getServicesForUser(roles, false, activeCaseLoadId, 12345, [], null)
       expect(
         output.some(service => service.heading === 'Apply, change or end an Electronic Monitoring Order (EMO)'),
       ).toEqual(visible)

--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -768,7 +768,7 @@ describe('getServicesForUser', () => {
     ])('user with roles $1, can see $2', (roles, visible) => {
       const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
       expect(
-        !!output.find(service => service.heading === 'Apply, change or end an Electronic Monitoring Order (EMO)'),
+        output.some(service => service.heading === 'Apply, change or end an Electronic Monitoring Order (EMO)'),
       ).toEqual(visible)
     })
   })

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -492,6 +492,14 @@ export default (
       navEnabled: true,
       enabled: () => userHasRoles([Role.DietAndAllergiesReport], roles),
     },
+    {
+      id: 'create-an-electronic-monitoring-order',
+      heading: 'Apply, change or end an Electronic Monitoring Order (EMO)',
+      description: '',
+      href: config.serviceUrls.createAnEMOrder.url,
+      navEnabled: true,
+      enabled: () => userHasRoles([Role.CreateAnEMOrder], roles),
+    },
   ]
     .filter(service => service.enabled())
     .map(service => {

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -498,7 +498,7 @@ export default (
       description: '',
       href: config.serviceUrls.createAnEMOrder.url,
       navEnabled: true,
-      enabled: () => userHasRoles([Role.CreateAnEMOrder], roles),
+      enabled: () => userHasRoles([Role.CreateAnEMOrder], roles) && ['DNI', 'WEI'].includes(activeCaseLoadId),
     },
   ]
     .filter(service => service.enabled())

--- a/server/services/utils/roles.ts
+++ b/server/services/utils/roles.ts
@@ -81,6 +81,7 @@ export enum Role {
   IncidentReportingApprove = 'INCIDENT_REPORTS__APPROVE',
   ManagePrisonerApps = 'MANAGING_PRISONER_APPS',
   DietAndAllergiesReport = 'DIET_AND_FOOD_ALLERGIES_REPORT',
+  CreateAnEMOrder = 'EM_CEMO__CREATE_ORDER',
 }
 export const userHasRoles = (rolesToCheck: string[], userRoles: string[]): boolean => {
   return rolesToCheck.some(role => userRoles.includes(role))


### PR DESCRIPTION
- Add the CEMO service to the list of available service
- Restrict access to users with the role `ROLE_EM_CEMO__CREATE_ORDER`
- Restrict access to users with activeCaseLoad as either `Doncaster` or `Wealstun`

## Future changes
- We're aware this change doesn't conform to how DPS would like us to roll out to different prisons but due to current time pressures, we have agreed in this slack thread that this is a suitable (and temporary) alternative.