### PR TITLE
Use active agencies to display cemo tile

### DIFF
--- a/scripts/getReleaseStatus.js
+++ b/scripts/getReleaseStatus.js
@@ -21,6 +21,7 @@ const endpoints = [
   { application: 'incidentReporting', urlEnv: 'INCIDENT_REPORTING_URL' },
   { application: 'caseNotesApi', urlEnv: 'CASE_NOTES_API_URL' },
   { application: 'prepareSomeoneForReleaseUi', urlEnv: 'PREPARE_SOMEONE_FOR_RELEASE_URL' },
+  { application: 'cemo', urlEnv: 'CEMO_URL' },
 ]
 
 function getApplicationInfo(url) {

--- a/scripts/getReleaseStatus.test.js
+++ b/scripts/getReleaseStatus.test.js
@@ -12,6 +12,7 @@ const whereaboutsApiUrl = 'https://whereabouts-api-dev.service.justice.gov.uk'
 const csipApiUrl = 'https://csip-api-dev.hmpps.service.justice.gov.uk'
 const caseNotesApiUrl = 'https://dev.offender-case-notes.service.justice.gov.uk'
 const prepareSomeoneForReleaseUrl = 'https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk'
+const cemoUrl = 'https://hmpps-electronic-monitoring-create-an-order-dev.hmpps.service.justice.gov.uk'
 const allUrls = [
   residentialLocationUrl,
   reportingUrl,
@@ -23,6 +24,7 @@ const allUrls = [
   whereaboutsApiUrl,
   caseNotesApiUrl,
   prepareSomeoneForReleaseUrl,
+  cemoUrl,
 ]
 
 function setMockSuccess(urls, body = { some: 'stuff', activeAgencies: ['agency1', 'agency2'] }) {

--- a/scripts/getReleaseStatus.test.js
+++ b/scripts/getReleaseStatus.test.js
@@ -82,6 +82,7 @@ describe('Get release status script', () => {
         { app: 'whereabouts', activeAgencies: ['agency1', 'agency2'] },
         { app: 'caseNotesApi', activeAgencies: ['agency1', 'agency2'] },
         { app: 'prepareSomeoneForReleaseUi', activeAgencies: ['agency1', 'agency2'] },
+        { app: 'cemo', activeAgencies: ['agency1', 'agency2'] },
       ]),
     )
   })
@@ -119,6 +120,7 @@ describe('Get release status script', () => {
         { app: 'whereabouts', activeAgencies: ['agency1', 'agency2'] },
         { app: 'caseNotesApi', activeAgencies: ['agency1', 'agency2'] },
         { app: 'prepareSomeoneForReleaseUi', activeAgencies: ['agency1', 'agency2'] },
+        { app: 'cemo', activeAgencies: ['agency1', 'agency2'] },
       ]),
     )
   })
@@ -148,6 +150,7 @@ describe('Get release status script', () => {
         { app: 'whereabouts', activeAgencies: ['agency1', 'agency2'] },
         { app: 'caseNotesApi', activeAgencies: ['agency1', 'agency2'] },
         { app: 'prepareSomeoneForReleaseUi', activeAgencies: ['agency1', 'agency2'] },
+        { app: 'cemo', activeAgencies: ['agency1', 'agency2'] },
       ]
 
       const [residentialLocationUrl, ...restUrls] = allUrls
@@ -170,6 +173,7 @@ describe('Get release status script', () => {
           { app: 'whereabouts', activeAgencies: ['agency1', 'agency2'] },
           { app: 'caseNotesApi', activeAgencies: ['agency1', 'agency2'] },
           { app: 'prepareSomeoneForReleaseUi', activeAgencies: ['agency1', 'agency2'] },
+          { app: 'cemo', activeAgencies: ['agency1', 'agency2'] },
         ]),
       )
     })
@@ -199,6 +203,7 @@ describe('Get release status script', () => {
           { app: 'whereabouts', activeAgencies: ['agency1', 'agency2'] },
           { app: 'caseNotesApi', activeAgencies: ['agency1', 'agency2'] },
           { app: 'prepareSomeoneForReleaseUi', activeAgencies: ['agency1', 'agency2'] },
+          { app: 'cemo', activeAgencies: ['agency1', 'agency2'] },
         ]),
       )
     })

--- a/server/@types/activeAgencies.ts
+++ b/server/@types/activeAgencies.ts
@@ -12,6 +12,7 @@ export enum ServiceName {
   WHEREABOUTS = 'whereabouts',
   INCIDENT_REPORTING = 'incidentReporting',
   PREPARE_SOMEONE_FOR_RELEASE = 'prepareSomeoneForReleaseUi',
+  CEMO = 'cemo',
 }
 
 export interface ServiceActiveAgencies {

--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -763,12 +763,12 @@ describe('getServicesForUser', () => {
 
   describe('Create an electronic monitoring order', () => {
     test.each([
-      [[], 'LEI', false],
-      [[Role.CreateAnEMOrder], 'LEI', false],
-      [[Role.CreateAnEMOrder], 'DNI', true],
-      [[Role.CreateAnEMOrder], 'WEI', true],
-    ])('user with roles %s, can see: %s', (roles, activeCaseLoadId, visible) => {
-      const output = getServicesForUser(roles, false, activeCaseLoadId, 12345, [], null)
+      [[], [], 'LEI', false],
+      [[Role.CreateAnEMOrder], [], 'LEI', false],
+      [[Role.CreateAnEMOrder], [{ app: ServiceName.CEMO, activeAgencies: ['ANOTHER'] }], 'LEI', false],
+      [[Role.CreateAnEMOrder], [{ app: ServiceName.CEMO, activeAgencies: ['LEI'] }], 'LEI', true],
+    ])('user with roles %s, can see: %s', (roles, activeServices, activeCaseLoadId, visible) => {
+      const output = getServicesForUser(roles, false, activeCaseLoadId, 12345, [], activeServices)
       expect(
         output.some(service => service.heading === 'Apply, change or end an Electronic Monitoring Order (EMO)'),
       ).toEqual(visible)

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -498,7 +498,9 @@ export default (
       description: '',
       href: config.serviceUrls.createAnEMOrder.url,
       navEnabled: true,
-      enabled: () => userHasRoles([Role.CreateAnEMOrder], roles) && ['DNI', 'WEI'].includes(activeCaseLoadId),
+      enabled: () =>
+        userHasRoles([Role.CreateAnEMOrder], roles) &&
+        isActiveInEstablishment(activeCaseLoadId, ServiceName.CEMO, activeServices, false),
     },
   ]
     .filter(service => service.enabled())

--- a/tests/setEnvVars.js
+++ b/tests/setEnvVars.js
@@ -8,3 +8,4 @@ process.env.WHEREABOUTS_API_URL = 'https://whereabouts-api-dev.service.justice.g
 process.env.CSIP_API_URL = 'https://csip-api-dev.hmpps.service.justice.gov.uk'
 process.env.CASE_NOTES_API_URL = 'https://dev.offender-case-notes.service.justice.gov.uk'
 process.env.PREPARE_SOMEONE_FOR_RELEASE_URL = 'https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk'
+process.env.CEMO_URL = 'https://hmpps-electronic-monitoring-create-an-order-dev.hmpps.service.justice.gov.uk'


### PR DESCRIPTION
- The Create an Electronic Monitoring Order was updated to publish the active agencies in this pull request: https://github.com/ministryofjustice/hmpps-electronic-monitoring-create-an-order/pull/296
- This change removes the hard coded agency values (`DNI` & `WEI`) that were previously added for the CEMO tile and replaces them with active agencies published by the CEMO service