### PR TITLE
Add allocate-key-worker and allocate-personal-officer services

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -6,6 +6,7 @@ SYSTEM_CLIENT_ID=clientid
 SYSTEM_CLIENT_SECRET=clientsecret
 HMPPS_AUTH_URL=http://localhost:9091/auth
 PRISON_API_URL=http://localhost:9091/prison
+ALLOCATIONS_API_URL=http://localhost:9091/allocations
 TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
 PRISONER_SEARCH_API_URL=http://external/prisoner-search
 DIGITAL_PRISON_SERVICE_URL=http://external/digital-prison-services

--- a/feature.env
+++ b/feature.env
@@ -56,6 +56,10 @@ MANAGE_OFFENCES_URL=https://external/manage-offences
 LEARNING_AND_WORK_PROGRESS_URL=https://external/learning-and-work-progress
 PREPARE_SOMEONE_FOR_RELEASE_URL=https://external/prepare-someone-for-release
 MANAGE_APPLICATIONS_URL=https://external/applications
+ALLOCATE_KEY_WORKERS_API_URL=https://external/allocate-key-worker-api
+ALLOCATE_KEY_WORKERS_UI_URL=https://external/allocate-key-worker-ui
+ALLOCATE_PERSONAL_OFFICERS_API_URL=https://external/allocate-personal-officer-api
+ALLOCATE_PERSONAL_OFFICERS_UI_URL=https://external/allocate-personal-officer-ui
 
 ACTIVITIES_ENABLED_PRISONS="LEI,RSI"
 APPOINTMENTS_ENABLED_PRISONS="LEI,RSI"

--- a/helm_deploy/hmpps-micro-frontend-components/templates/services-cronjob.yaml
+++ b/helm_deploy/hmpps-micro-frontend-components/templates/services-cronjob.yaml
@@ -44,6 +44,10 @@ spec:
                 value: "{{ index .Values "generic-service" "env" "CEMO_URL" }}"
               - name: MANAGE_APPLICATIONS_URL
                 value: "{{ index .Values "generic-service" "env" "MANAGE_APPLICATIONS_URL" }}"
+              - name: ALLOCATE_KEY_WORKERS_API_URL
+                value: "{{ index .Values "generic-service" "env" "ALLOCATE_KEY_WORKERS_API_URL" }}"
+              - name: ALLOCATE_PERSONAL_OFFICERS_API_URL
+                value: "{{ index .Values "generic-service" "env" "ALLOCATE_PERSONAL_OFFICERS_API_URL" }}"
               - name: REDIS_HOST
                 valueFrom:
                   secretKeyRef:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -68,6 +68,11 @@ generic-service:
     MANAGE_APPLICATIONS_URL: https://managing-prisoner-apps-staff-dev.hmpps.service.justice.gov.uk
     ESTABLISHMENT_ROLL_URL: https://prison-roll-count-dev.hmpps.service.justice.gov.uk
     CEMO_URL: https://hmpps-electronic-monitoring-create-an-order-dev.hmpps.service.justice.gov.uk
+    ALLOCATIONS_API_URL: https://keyworker-api-dev.prison.service.justice.gov.uk
+    ALLOCATE_KEY_WORKERS_API_URL: https://keyworker-api-dev.prison.service.justice.gov.uk/KEY_WORKER
+    ALLOCATE_KEY_WORKERS_UI_URL: https://allocate-key-workers-dev.hmpps.service.justice.gov.uk/key-worker
+    ALLOCATE_PERSONAL_OFFICERS_API_URL: https://keyworker-api-dev.prison.service.justice.gov.uk/PERSONAL_OFFICER
+    ALLOCATE_PERSONAL_OFFICERS_UI_URL: https://allocate-key-workers-dev.hmpps.service.justice.gov.uk/personal-officer
 
     # Feature
     ACTIVITIES_ENABLED_PRISONS: "LEI,RSI,LPI"

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -65,6 +65,11 @@ generic-service:
     MANAGE_APPLICATIONS_URL: https://managing-prisoner-apps-staff-preprod.hmpps.service.justice.gov.uk
     ESTABLISHMENT_ROLL_URL: https://prison-roll-count-preprod.hmpps.service.justice.gov.uk
     CEMO_URL: https://hmpps-electronic-monitoring-create-an-order-preprod.hmpps.service.justice.gov.uk
+    ALLOCATIONS_API_URL: https://keyworker-api-preprod.prison.service.justice.gov.uk
+    ALLOCATE_KEY_WORKERS_API_URL: https://keyworker-api-preprod.prison.service.justice.gov.uk/KEY_WORKER
+    ALLOCATE_KEY_WORKERS_UI_URL: https://allocate-key-workers-preprod.hmpps.service.justice.gov.uk/key-worker
+    ALLOCATE_PERSONAL_OFFICERS_API_URL: https://keyworker-api-preprod.prison.service.justice.gov.uk/PERSONAL_OFFICER
+    ALLOCATE_PERSONAL_OFFICERS_UI_URL: https://allocate-key-workers-preprod.hmpps.service.justice.gov.uk/personal-officer
 
     # Feature
     ACTIVITIES_ENABLED_PRISONS: "RSI,LPI"

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -70,6 +70,11 @@ generic-service:
     MANAGE_APPLICATIONS_URL: https://managing-prisoner-apps-staff.hmpps.service.justice.gov.uk
     ESTABLISHMENT_ROLL_URL: https://prison-roll-count.hmpps.service.justice.gov.uk
     CEMO_URL: https://hmpps-electronic-monitoring-create-an-order.hmpps.service.justice.gov.uk
+    ALLOCATIONS_API_URL: https://keyworker-api.prison.service.justice.gov.uk
+    ALLOCATE_KEY_WORKERS_API_URL: https://keyworker-api.prison.service.justice.gov.uk/KEY_WORKER
+    ALLOCATE_KEY_WORKERS_UI_URL: https://allocate-key-workers.hmpps.service.justice.gov.uk/key-worker
+    ALLOCATE_PERSONAL_OFFICERS_API_URL: https://keyworker-api.prison.service.justice.gov.uk/PERSONAL_OFFICER
+    ALLOCATE_PERSONAL_OFFICERS_UI_URL: https://allocate-key-workers.hmpps.service.justice.gov.uk/personal-officer
 
     # Feature
     ACTIVITIES_ENABLED_PRISONS: "RSI,LPI"

--- a/integration_tests/cypress.config.ts
+++ b/integration_tests/cypress.config.ts
@@ -5,6 +5,7 @@ import manageUsersApi from './integration_tests/mockApis/manageUsersApi'
 import tokenVerification from './integration_tests/mockApis/tokenVerification'
 import prisonApi from './integration_tests/mockApis/prisonApi'
 import dps from './integration_tests/mockApis/dps'
+import allocationsApi from './integration_tests/mockApis/allocationsApi'
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -25,6 +26,7 @@ export default defineConfig({
         ...prisonApi,
         ...tokenVerification,
         ...dps,
+        ...allocationsApi,
       })
     },
     baseUrl: 'http://localhost:3007',

--- a/integration_tests/feature.env
+++ b/integration_tests/feature.env
@@ -2,6 +2,7 @@ PORT=3007
 HMPPS_AUTH_URL=http://localhost:9091/auth
 MANAGE_USERS_API_URL=http://localhost:9091/manage-users-api
 PRISON_API_URL=http://localhost:9091/prison
+ALLOCATIONS_API_URL=http://localhost:9091/allocations
 TOKEN_VERIFICATION_API_URL=http://localhost:9091/verification
 TOKEN_VERIFICATION_ENABLED=true
 REDIS_ENABLED=false

--- a/integration_tests/integration_tests/e2e/footer.cy.ts
+++ b/integration_tests/integration_tests/e2e/footer.cy.ts
@@ -9,6 +9,7 @@ context('Footer', () => {
     cy.task('stubCaseloads')
     cy.task('stubLocations')
     cy.task('stubKeyworkerRoles')
+    cy.task('stubGetStaffAllocationPolicies')
   })
 
   it('Services menu visible in footer', () => {

--- a/integration_tests/integration_tests/e2e/header.cy.ts
+++ b/integration_tests/integration_tests/e2e/header.cy.ts
@@ -13,6 +13,7 @@ context('Header', () => {
     cy.task('stubKeyworkerRoles')
     cy.task('stubSearchPage')
     cy.task('stubCaseloadSwitcherPage')
+    cy.task('stubGetStaffAllocationPolicies')
   })
 
   it('Phase banner visible in header', () => {

--- a/integration_tests/integration_tests/mockApis/allocationsApi.ts
+++ b/integration_tests/integration_tests/mockApis/allocationsApi.ts
@@ -1,0 +1,26 @@
+/* eslint-disable import/no-relative-packages */
+import { stubFor } from './wiremock'
+import { StaffAllocationPolicies } from '../../../server/data/AllocationsApiClient'
+
+const stubGetStaffAllocationPolicies = (
+  response: StaffAllocationPolicies = {
+    policies: [],
+  },
+) =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPattern: '/prisons/.*/staff/.*/job-classifications',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: response,
+    },
+  })
+
+export default {
+  stubGetStaffAllocationPolicies,
+}

--- a/integration_tests/integration_tests/mockApis/allocationsApi.ts
+++ b/integration_tests/integration_tests/mockApis/allocationsApi.ts
@@ -10,7 +10,7 @@ const stubGetStaffAllocationPolicies = (
   stubFor({
     request: {
       method: 'GET',
-      urlPattern: '/prisons/.*/staff/.*/job-classifications',
+      urlPattern: '/allocations/prisons/.*/staff/.*/job-classifications',
     },
     response: {
       status: 200,

--- a/scripts/getReleaseStatus.js
+++ b/scripts/getReleaseStatus.js
@@ -23,6 +23,8 @@ const endpoints = [
   { application: 'prepareSomeoneForReleaseUi', urlEnv: 'PREPARE_SOMEONE_FOR_RELEASE_URL' },
   { application: 'cemo', urlEnv: 'CEMO_URL' },
   { application: 'manageApplications', urlEnv: 'MANAGE_APPLICATIONS_URL' },
+  { application: 'allocateKeyWorkers', urlEnv: 'ALLOCATE_KEY_WORKERS_API_URL' },
+  { application: 'allocatePersonalOfficers', urlEnv: 'ALLOCATE_PERSONAL_OFFICERS_API_URL' },
 ]
 
 function getApplicationInfo(url) {

--- a/server/@types/activeAgencies.ts
+++ b/server/@types/activeAgencies.ts
@@ -14,6 +14,8 @@ export enum ServiceName {
   PREPARE_SOMEONE_FOR_RELEASE = 'prepareSomeoneForReleaseUi',
   CEMO = 'cemo',
   MANAGE_APPLICATIONS = 'manageApplications',
+  ALLOCATE_KEY_WORKERS = 'allocateKeyWorkers',
+  ALLOCATE_PERSONAL_OFFICERS = 'allocatePersonalOfficers',
 }
 
 export interface ServiceActiveAgencies {

--- a/server/config.ts
+++ b/server/config.ts
@@ -83,6 +83,14 @@ export default {
       },
       agent: new AgentConfig(Number(get('PRISON_API_TIMEOUT_DEADLINE', 20000))),
     },
+    allocationsApi: {
+      url: get('ALLOCATIONS_API_URL', 'http://localhost:8082', requiredInProduction),
+      timeout: {
+        response: Number(get('ALLOCATIONS_API_TIMEOUT_RESPONSE', 3000)),
+        deadline: Number(get('ALLOCATIONS_API_TIMEOUT_DEADLINE', 3000)),
+      },
+      agent: new AgentConfig(Number(get('ALLOCATIONS_API_TIMEOUT_DEADLINE', 3000))),
+    },
   },
   supportUrl: get('SUPPORT_URL', 'http://localhost:3001', requiredInProduction),
   domain: get('INGRESS_URL', 'http://localhost:3000', requiredInProduction),
@@ -230,6 +238,12 @@ export default {
     },
     createAnEMOrder: {
       url: get('CEMO_URL', 'http://localhost:3001', requiredInProduction),
+    },
+    allocateKeyWorkers: {
+      url: get('ALLOCATE_KEY_WORKERS_UI_URL', 'http://localhost:3001', requiredInProduction),
+    },
+    allocatePersonalOfficers: {
+      url: get('ALLOCATE_PERSONAL_OFFICERS_UI_URL', 'http://localhost:3001', requiredInProduction),
     },
   },
   features: {

--- a/server/controllers/componentsController.test.ts
+++ b/server/controllers/componentsController.test.ts
@@ -3,6 +3,7 @@ import ContentfulService from '../services/contentfulService'
 import config from '../config'
 import { activeCaseLoadMock, hmppsUserMock, prisonUserMock, servicesMock } from '../../tests/mocks/hmppsUserMock'
 import { DEFAULT_USER_ACCESS } from '../services/userService'
+import { PrisonUserAccess } from '../interfaces/hmppsUser'
 
 const contentfulServiceMock = {
   getManagedPages: () => [
@@ -46,10 +47,11 @@ const expectedFooterViewModel: FooterViewModel = {
   component: 'footer',
 }
 
-const expectedMeta = {
+const expectedMeta: PrisonUserAccess = {
   activeCaseLoad: activeCaseLoadMock,
   caseLoads: [activeCaseLoadMock],
   services: servicesMock,
+  allocationJobResponsibilities: [],
 }
 
 describe('componentsController', () => {

--- a/server/controllers/componentsController.ts
+++ b/server/controllers/componentsController.ts
@@ -91,7 +91,12 @@ export default (
       {
         meta:
           user.authSource === 'nomis'
-            ? { caseLoads: user.caseLoads, activeCaseLoad: user.activeCaseLoad, services: user.services }
+            ? {
+                caseLoads: user.caseLoads,
+                activeCaseLoad: user.activeCaseLoad,
+                services: user.services,
+                allocationJobResponsibilities: user.allocationJobResponsibilities,
+              }
             : DEFAULT_USER_ACCESS,
       },
     )

--- a/server/data/AllocationsApiClient.ts
+++ b/server/data/AllocationsApiClient.ts
@@ -1,0 +1,17 @@
+import RestClient from './restClient'
+
+export type StaffAllocationPolicies = {
+  policies: ('KEY_WORKER' | 'PERSONAL_OFFICER')[]
+}
+
+export default class AllocationsApiClient {
+  constructor(private restClient: RestClient) {}
+
+  private async get<T>(args: object): Promise<T> {
+    return this.restClient.get<T>(args)
+  }
+
+  async getStaffAllocationPolicies(prisonCode: string, staffId: number) {
+    return this.get<StaffAllocationPolicies>({ path: `/prisons/${prisonCode}/staff/${staffId}/job-classifications` })
+  }
+}

--- a/server/data/AllocationsApiClient.ts
+++ b/server/data/AllocationsApiClient.ts
@@ -1,4 +1,5 @@
 import RestClient from './restClient'
+import logger from '../../logger'
 
 export type StaffAllocationPolicies = {
   policies: ('KEY_WORKER' | 'PERSONAL_OFFICER')[]
@@ -12,6 +13,13 @@ export default class AllocationsApiClient {
   }
 
   async getStaffAllocationPolicies(prisonCode: string, staffId: number) {
-    return this.get<StaffAllocationPolicies>({ path: `/prisons/${prisonCode}/staff/${staffId}/job-classifications` })
+    try {
+      return await this.get<StaffAllocationPolicies>({
+        path: `/prisons/${prisonCode}/staff/${staffId}/job-classifications`,
+      })
+    } catch (e) {
+      logger.error('Error retrieving Staff Allocation Policies', e)
+      return { policies: [] }
+    }
   }
 }

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -16,6 +16,7 @@ import TokenStore from './tokenStore'
 import config, { ApiConfig } from '../config'
 import RestClient, { RestClientBuilder as CreateRestClientBuilder } from './restClient'
 import PrisonApiClient from './prisonApiClient'
+import AllocationsApiClient from './AllocationsApiClient'
 
 type RestClientBuilder<T> = (token: string) => T
 
@@ -30,6 +31,11 @@ export default function restClientBuilder<T>(
 
 export const dataAccess = {
   prisonApiClientBuilder: restClientBuilder<PrisonApiClient>('Prison API', config.apis.prisonApi, PrisonApiClient),
+  allocationsApiClientBuilder: restClientBuilder<AllocationsApiClient>(
+    'Allocations API',
+    config.apis.allocationsApi,
+    AllocationsApiClient,
+  ),
   getSystemToken: systemTokenBuilder(new TokenStore(createRedisClient())),
   applicationInfo,
 }

--- a/server/interfaces/hmppsUser.ts
+++ b/server/interfaces/hmppsUser.ts
@@ -21,6 +21,7 @@ export interface PrisonUserAccess {
   caseLoads: CaseLoad[]
   activeCaseLoad: CaseLoad | null
   services: Service[]
+  allocationJobResponsibilities: ('KEY_WORKER' | 'PERSONAL_OFFICER')[]
 }
 
 /**

--- a/server/routes/header.test.ts
+++ b/server/routes/header.test.ts
@@ -36,6 +36,7 @@ jest.mock('express-jwt', () => ({
 
 let app: App
 let prisonApi: nock.Scope
+let allocationsApi: nock.Scope
 
 const redisClient = createRedisClient()
 async function ensureConnected() {
@@ -46,6 +47,7 @@ async function ensureConnected() {
 
 beforeEach(async () => {
   prisonApi = nock(config.apis.prisonApi.url)
+  allocationsApi = nock(config.apis.allocationsApi.url)
 
   await ensureConnected()
   redisClient.del('TOKEN_USER_meta_data')
@@ -72,6 +74,7 @@ describe('GET /header', () => {
       ])
       prisonApi.get('/api/staff/11111/LEI/roles/KW').reply(200, 'true')
       prisonApi.get('/api/users/me/locations').reply(200, [])
+      allocationsApi.get('/prisons/LEI/staff/11111/job-classifications').reply(200, { policies: [] })
     })
 
     it('should render digital prison services title', () => {

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -7,7 +7,7 @@ import { createRedisClient } from '../data/redisClient'
 import CacheService from './cacheService'
 
 export const services = () => {
-  const { prisonApiClientBuilder } = dataAccess
+  const { prisonApiClientBuilder, allocationsApiClientBuilder } = dataAccess
 
   const apolloClient = new ApolloClient({
     cache: new InMemoryCache(),
@@ -25,7 +25,7 @@ export const services = () => {
 
   const contentfulService = new ContentfulService(apolloClient)
   const cacheService = new CacheService(createRedisClient(), config.redis.cacheTimeout)
-  const userService = new UserService(prisonApiClientBuilder, cacheService)
+  const userService = new UserService(prisonApiClientBuilder, allocationsApiClientBuilder, cacheService)
 
   return {
     userService,

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -55,12 +55,16 @@ export default class UserService {
         prisonApiClient,
         allocationsApiClient,
       )
-      const allocation = await this.getAllocationPolicies(user, activeCaseLoad?.caseLoadId, allocationsApiClient)
+      const allocationPolicies = await this.getAllocationPolicies(
+        user,
+        activeCaseLoad?.caseLoadId,
+        allocationsApiClient,
+      )
       const userAccess: PrisonUserAccess = {
         caseLoads,
         activeCaseLoad,
         services,
-        allocationJobResponsibilities: allocation.policies,
+        allocationJobResponsibilities: allocationPolicies.policies,
       }
       await this.setCache(user, userAccess)
 
@@ -105,7 +109,7 @@ export default class UserService {
     prisonApiClient: PrisonApiClient,
     allocationsApiClient: AllocationsApiClient,
   ): Promise<Service[]> {
-    const [locations, isKeyworker, allocation] = await Promise.all([
+    const [locations, isKeyworker, allocationPolicies] = await Promise.all([
       prisonApiClient.getUserLocations(),
       prisonApiClient.getIsKeyworker(caseLoadId, user.staffId),
       this.getAllocationPolicies(user, caseLoadId, allocationsApiClient),
@@ -118,7 +122,7 @@ export default class UserService {
     return getServicesForUser(
       user.userRoles,
       isKeyworker,
-      allocation,
+      allocationPolicies,
       caseLoadId ?? null,
       user.staffId,
       locations,

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -8,6 +8,7 @@ import config from '../config'
 import { PrisonUser, PrisonUserAccess } from '../interfaces/hmppsUser'
 import { Service } from '../interfaces/Service'
 import { CaseLoad } from '../interfaces/caseLoad'
+import AllocationsApiClient, { StaffAllocationPolicies } from '../data/AllocationsApiClient'
 
 export const API_COOL_OFF_MINUTES = 5
 export const API_ERROR_LIMIT = 100
@@ -15,6 +16,7 @@ export const DEFAULT_USER_ACCESS: PrisonUserAccess = {
   caseLoads: [],
   activeCaseLoad: null,
   services: [],
+  allocationJobResponsibilities: [],
 }
 
 export default class UserService {
@@ -22,6 +24,7 @@ export default class UserService {
 
   constructor(
     private readonly prisonApiClientBuilder: RestClientBuilder<PrisonApiClient>,
+    private readonly allocationsApiClientBuilder: RestClientBuilder<AllocationsApiClient>,
     private readonly cacheService: CacheService,
   ) {}
 
@@ -33,6 +36,7 @@ export default class UserService {
 
     try {
       const prisonApiClient = this.prisonApiClientBuilder(user.token)
+      const allocationsApiClient = this.allocationsApiClientBuilder(user.token)
       const caseLoads = await prisonApiClient.getUserCaseLoads()
       const activeCaseLoad = caseLoads.find(caseLoad => caseLoad.currentlyActive)
 
@@ -45,8 +49,19 @@ export default class UserService {
         return cache
       }
 
-      const services = await this.getServicesForUser(user, activeCaseLoad?.caseLoadId, prisonApiClient)
-      const userAccess: PrisonUserAccess = { caseLoads, activeCaseLoad, services }
+      const services = await this.getServicesForUser(
+        user,
+        activeCaseLoad?.caseLoadId,
+        prisonApiClient,
+        allocationsApiClient,
+      )
+      const allocation = await this.getAllocationPolicies(user, activeCaseLoad?.caseLoadId, allocationsApiClient)
+      const userAccess: PrisonUserAccess = {
+        caseLoads,
+        activeCaseLoad,
+        services,
+        allocationJobResponsibilities: allocation.policies,
+      }
       await this.setCache(user, userAccess)
 
       // successfully retrieved user access, reset error counter
@@ -88,17 +103,41 @@ export default class UserService {
     user: PrisonUser,
     caseLoadId: string,
     prisonApiClient: PrisonApiClient,
+    allocationsApiClient: AllocationsApiClient,
   ): Promise<Service[]> {
-    const [locations, isKeyworker] = await Promise.all([
+    const [locations, isKeyworker, allocation] = await Promise.all([
       prisonApiClient.getUserLocations(),
       prisonApiClient.getIsKeyworker(caseLoadId, user.staffId),
+      this.getAllocationPolicies(user, caseLoadId, allocationsApiClient),
     ])
 
     const activeServices = config.features.servicesStore.enabled
       ? await this.cacheService.getData<ServiceActiveAgencies[]>('applicationInfo')
       : null
 
-    return getServicesForUser(user.userRoles, isKeyworker, caseLoadId ?? null, user.staffId, locations, activeServices)
+    return getServicesForUser(
+      user.userRoles,
+      isKeyworker,
+      allocation,
+      caseLoadId ?? null,
+      user.staffId,
+      locations,
+      activeServices,
+    )
+  }
+
+  private async getAllocationPolicies(
+    user: PrisonUser,
+    caseLoadId: string,
+    allocationsApiClient: AllocationsApiClient,
+  ) {
+    const allocationCacheKey = `${user.username}_${caseLoadId}_allocation`
+    let allocation = await this.cacheService.getData<StaffAllocationPolicies>(allocationCacheKey)
+    if (!allocation?.policies) {
+      allocation = await allocationsApiClient.getStaffAllocationPolicies(caseLoadId, user.staffId)
+      await this.cacheService.setData(allocationCacheKey, allocation)
+    }
+    return allocation
   }
 
   private handleError(error: Error) {

--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -776,4 +776,57 @@ describe('getServicesForUser', () => {
       ).toEqual(visible)
     })
   })
+
+  describe('Allocate Key Worker', () => {
+    test.each`
+      roles               | activeServices                                                          | visible
+      ${[Role.OmicAdmin]} | ${[{ app: ServiceName.ALLOCATE_KEY_WORKERS, activeAgencies: ['LEI'] }]} | ${true}
+      ${[]}               | ${[{ app: ServiceName.ALLOCATE_KEY_WORKERS, activeAgencies: ['LEI'] }]} | ${false}
+      ${[Role.OmicAdmin]} | ${[{ app: ServiceName.ALLOCATE_KEY_WORKERS, activeAgencies: ['MOR'] }]} | ${false}
+    `('user with roles: $roles, can see: $visible', ({ roles, visible, activeServices }) => {
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], activeServices)
+      expect(
+        !!output.find(
+          service =>
+            service.description === 'Allocate key workers to prisoners and manage key work in your establishment.',
+        ),
+      ).toEqual(visible)
+    })
+  })
+
+  describe('My Key Worker allocation', () => {
+    test.each`
+      roles               | activeServices                                                          | visible
+      ${[Role.KeyWorker]} | ${[{ app: ServiceName.ALLOCATE_KEY_WORKERS, activeAgencies: ['LEI'] }]} | ${true}
+      ${[]}               | ${[{ app: ServiceName.ALLOCATE_KEY_WORKERS, activeAgencies: ['LEI'] }]} | ${false}
+      ${[Role.KeyWorker]} | ${[{ app: ServiceName.ALLOCATE_KEY_WORKERS, activeAgencies: ['MOR'] }]} | ${false}
+    `('user with roles: $roles, can see: $visible', ({ roles, visible, activeServices }) => {
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], activeServices)
+      expect(!!output.find(service => service.heading === 'My key worker allocations')).toEqual(visible)
+    })
+  })
+
+  describe('Allocate Personal Officer', () => {
+    test.each`
+      roles                             | activeServices                                                                | visible
+      ${[Role.PersonalOfficerAllocate]} | ${[{ app: ServiceName.ALLOCATE_PERSONAL_OFFICERS, activeAgencies: ['LEI'] }]} | ${true}
+      ${[]}                             | ${[{ app: ServiceName.ALLOCATE_PERSONAL_OFFICERS, activeAgencies: ['LEI'] }]} | ${false}
+      ${[Role.PersonalOfficerAllocate]} | ${[{ app: ServiceName.ALLOCATE_PERSONAL_OFFICERS, activeAgencies: ['MOR'] }]} | ${false}
+    `('user with roles: $roles, can see: $visible', ({ roles, visible, activeServices }) => {
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], activeServices)
+      expect(!!output.find(service => service.heading === 'Personal officers')).toEqual(visible)
+    })
+  })
+
+  describe('My Personal Officer allocation', () => {
+    test.each`
+      roles                     | activeServices                                                                | visible
+      ${[Role.PersonalOfficer]} | ${[{ app: ServiceName.ALLOCATE_PERSONAL_OFFICERS, activeAgencies: ['LEI'] }]} | ${true}
+      ${[]}                     | ${[{ app: ServiceName.ALLOCATE_PERSONAL_OFFICERS, activeAgencies: ['LEI'] }]} | ${false}
+      ${[Role.PersonalOfficer]} | ${[{ app: ServiceName.ALLOCATE_PERSONAL_OFFICERS, activeAgencies: ['MOR'] }]} | ${false}
+    `('user with roles: $roles, can see: $visible', ({ roles, visible, activeServices }) => {
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], activeServices)
+      expect(!!output.find(service => service.heading === 'My personal officer allocations')).toEqual(visible)
+    })
+  })
 })

--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -50,6 +50,8 @@ jest.mock('../../config', () => ({
     establishmentRoll: { url: 'url' },
     manageApplications: { url: 'url' },
     createAnEMOrder: { url: 'url' },
+    allocateKeyWorkers: { url: 'url' },
+    allocatePersonalOfficers: { url: 'url' },
   },
 }))
 
@@ -60,7 +62,7 @@ describe('getServicesForUser', () => {
       ${[Role.GlobalSearch]} | ${true}
       ${[]}                  | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Global search')).toEqual(visible)
     })
   })
@@ -71,7 +73,7 @@ describe('getServicesForUser', () => {
       ${true}     | ${true}
       ${false}    | ${false}
     `('user with staffRoles: $staffRoles, can see: $visible', ({ isKeyworker, visible }) => {
-      const output = getServicesForUser([], isKeyworker, 'LEI', 12345, [], null)
+      const output = getServicesForUser([], isKeyworker, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'My key worker allocation')).toEqual(visible)
     })
   })
@@ -82,7 +84,7 @@ describe('getServicesForUser', () => {
       ${[]} | ${[{ app: 'whereabouts', activeAgencies: ['LEI'] }]} | ${true}
       ${[]} | ${[{ app: 'whereabouts', activeAgencies: ['MOR'] }]} | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible, activeServices }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], activeServices)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], activeServices)
       expect(!!output.find(service => service.heading === 'Prisoner whereabouts')).toEqual(visible)
     })
   })
@@ -93,14 +95,14 @@ describe('getServicesForUser', () => {
       ${[Role.CellMove]} | ${true}
       ${[]}              | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Change someone’s cell')).toEqual(visible)
     })
   })
 
   describe('Check my diary', () => {
     it('should return true', () => {
-      const output = getServicesForUser([], false, 'LEI', 12345, [], null)
+      const output = getServicesForUser([], false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Check my diary')).toEqual(true)
     })
   })
@@ -111,7 +113,7 @@ describe('getServicesForUser', () => {
       ${[Role.MaintainIncentiveLevels]} | ${true}
       ${[]}                             | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Incentives')).toEqual(visible)
     })
   })
@@ -122,7 +124,7 @@ describe('getServicesForUser', () => {
       ${'LEI'}       | ${true}
       ${'SOM'}       | ${false}
     `('caseload: $activeCaseLoad, can see: $visible', ({ activeCaseLoad, visible }) => {
-      const output = getServicesForUser([], false, activeCaseLoad, 12345, [], null)
+      const output = getServicesForUser([], false, { policies: [] }, activeCaseLoad, 12345, [], null)
       expect(!!output.find(service => service.heading === 'Use of force incidents')).toEqual(visible)
     })
   })
@@ -145,7 +147,7 @@ describe('getServicesForUser', () => {
       ${[Role.PathfinderLocalReader, Role.PathfinderLocalReader]} | ${true}
       ${[]}                                                       | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Pathfinder')).toEqual(visible)
     })
   })
@@ -161,7 +163,7 @@ describe('getServicesForUser', () => {
       ${[Role.LicenceReadOnly]} | ${true}
       ${[]}                     | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Home Detention Curfew')).toEqual(visible)
     })
   })
@@ -173,7 +175,7 @@ describe('getServicesForUser', () => {
       ${[{}]}   | ${true}  | ${'MDI'}
       ${[{}]}   | ${true}  | ${'DNI'}
     `('user with locations: $locations.length, can see: $visible', ({ locations, visible, activeCaseLoadId }) => {
-      const output = getServicesForUser([], false, activeCaseLoadId, 12345, locations, null)
+      const output = getServicesForUser([], false, { policies: [] }, activeCaseLoadId, 12345, locations, null)
       expect(!!output.find(service => service.heading === 'Establishment roll check')).toEqual(visible)
     })
   })
@@ -186,7 +188,7 @@ describe('getServicesForUser', () => {
       ${[Role.OmicAdmin, Role.KeyworkerMonitor]} | ${true}
       ${[]}                                      | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Key workers')).toEqual(visible)
     })
   })
@@ -199,7 +201,7 @@ describe('getServicesForUser', () => {
       ${[Role.AllocationsManager, Role.AllocationsCaseManager]} | ${true}
       ${[]}                                                     | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'POM cases')).toEqual(visible)
     })
   })
@@ -214,7 +216,7 @@ describe('getServicesForUser', () => {
       ${[Role.MaintainAccessRoles, Role.MaintainAccessRolesAdmin, Role.MaintainOauthUsers, Role.AuthGroupManager]} | ${true}
       ${[]}                                                                                                        | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Manage user accounts')).toEqual(visible)
     })
   })
@@ -228,7 +230,7 @@ describe('getServicesForUser', () => {
       ${[Role.CreateCategorisation, Role.CreateRecategorisation, Role.ApproveCategorisation, Role.CategorisationSecurity]} | ${true}
       ${[]}                                                                                                                | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Categorisation')).toEqual(visible)
     })
   })
@@ -240,7 +242,7 @@ describe('getServicesForUser', () => {
       ${[Role.PecsPrison]}               | ${true}
       ${[]}                              | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Book a secure move')).toEqual(visible)
     })
   })
@@ -253,7 +255,7 @@ describe('getServicesForUser', () => {
       ${[Role.SocHq]}                                     | ${true}
       ${[]}                                               | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Manage SOC cases')).toEqual(visible)
     })
   })
@@ -267,7 +269,7 @@ describe('getServicesForUser', () => {
       ${[Role.PcmsAudit]}                                                                      | ${true}
       ${[]}                                                                                    | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Prisoner communication monitoring service')).toEqual(visible)
     })
   })
@@ -316,7 +318,7 @@ describe('getServicesForUser', () => {
       ${'No cache, in env var'}                       | ${'LEI'}            | ${true}  | ${null}
       ${'No cache, not in env var'}                   | ${'NOT_IN_ENV_VAR'} | ${false} | ${null}
     `('caseload: $desc, can see: $visible', ({ activeCaseLoad, visible, activeServices }) => {
-      const output = getServicesForUser([], false, activeCaseLoad, 12345, [], activeServices)
+      const output = getServicesForUser([], false, { policies: [] }, activeCaseLoad, 12345, [], activeServices)
       expect(!!output.find(service => service.heading === 'Adjudications')).toEqual(visible)
     })
   })
@@ -327,7 +329,7 @@ describe('getServicesForUser', () => {
       ${[Role.ManagePrisonVisits]} | ${true}
       ${[]}                        | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Manage prison visits')).toEqual(visible)
     })
   })
@@ -338,7 +340,7 @@ describe('getServicesForUser', () => {
       ${[Role.PvbRequests]} | ${true}
       ${[]}                 | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Online visit requests')).toEqual(visible)
     })
   })
@@ -349,7 +351,7 @@ describe('getServicesForUser', () => {
       ${[Role.SocialVideoCalls]} | ${true}
       ${[]}                      | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Secure social video calls')).toEqual(visible)
     })
   })
@@ -362,7 +364,7 @@ describe('getServicesForUser', () => {
       ${[Role.SlmAdmin]}                      | ${true}
       ${[]}                                   | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Check Rule 39 mail')).toEqual(visible)
     })
   })
@@ -373,14 +375,14 @@ describe('getServicesForUser', () => {
       ${'LEI'}       | ${true}
       ${'SOM'}       | ${false}
     `('caseload: $activeCaseLoad, can see: $visible', ({ activeCaseLoad, visible }) => {
-      const output = getServicesForUser([], false, activeCaseLoad, 12345, [], null)
+      const output = getServicesForUser([], false, { policies: [] }, activeCaseLoad, 12345, [], null)
       expect(!!output.find(service => service.heading === 'Welcome people into prison')).toEqual(visible)
     })
   })
 
   describe('Submit an Intelligence Report', () => {
     it('should return true', () => {
-      const output = getServicesForUser([], false, 'LEI', 12345, [], null)
+      const output = getServicesForUser([], false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Submit an Intelligence Report')).toEqual(true)
     })
   })
@@ -391,7 +393,7 @@ describe('getServicesForUser', () => {
       ${[Role.ManageIntelligenceUser]} | ${true}
       ${[]}                            | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Intelligence management service')).toEqual(visible)
       expect(!!output.find(service => service.description === 'Manage and view intelligence reports')).toEqual(visible)
     })
@@ -407,7 +409,7 @@ describe('getServicesForUser', () => {
       ${[Role.RestrictedPatientMigration]}                                                                                             | ${true}
       ${[]}                                                                                                                            | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Manage restricted patients')).toEqual(visible)
     })
   })
@@ -423,7 +425,7 @@ describe('getServicesForUser', () => {
       ${[Role.LicenceAdmin]}                                                                  | ${true}
       ${[]}                                                                                   | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Create and vary a licence')).toEqual(visible)
     })
   })
@@ -450,7 +452,7 @@ describe('getServicesForUser', () => {
       ${'No application data cached, in env var'}     | ${'LEI'}            | ${true}  | ${[]}
       ${'No application data cached, not in env var'} | ${'NOT_IN_ENV_VAR'} | ${false} | ${[]}
     `('caseload: $desc, can see: $visible', ({ activeCaseLoad, visible, activeServices }) => {
-      const output = getServicesForUser([], false, activeCaseLoad, 12345, [], activeServices)
+      const output = getServicesForUser([], false, { policies: [] }, activeCaseLoad, 12345, [], activeServices)
       expect(!!output.find(service => service.heading === 'Activities, unlock and attendance')).toEqual(visible)
     })
   })
@@ -469,7 +471,7 @@ describe('getServicesForUser', () => {
       ${'No application data cached, in env var (activities)'}     | ${'LEI'}            | ${true}  | ${[]}
       ${'No application data cached, not in env var (activities)'} | ${'NOT_IN_ENV_VAR'} | ${false} | ${[]}
     `('caseload: $desc, can see: $visible', ({ activeCaseLoad, visible, activeServices }) => {
-      const output = getServicesForUser([], false, activeCaseLoad, 12345, [], activeServices)
+      const output = getServicesForUser([], false, { policies: [] }, activeCaseLoad, 12345, [], activeServices)
       expect(!!output.find(service => service.heading === 'Appointments scheduling and attendance')).toEqual(visible)
     })
   })
@@ -488,7 +490,7 @@ describe('getServicesForUser', () => {
       ${'No application data cached, in env var (activities)'}     | ${'LEI'}            | ${true}  | ${[]}
       ${'No application data cached, not in env var (activities)'} | ${'NOT_IN_ENV_VAR'} | ${false} | ${[]}
     `('caseload: $desc, can see: $visible', ({ activeCaseLoad, visible, activeServices }) => {
-      const output = getServicesForUser([], false, activeCaseLoad, 12345, [], activeServices)
+      const output = getServicesForUser([], false, { policies: [] }, activeCaseLoad, 12345, [], activeServices)
       expect(!!output.find(service => service.heading === 'People due to leave')).toEqual(visible)
     })
   })
@@ -500,7 +502,7 @@ describe('getServicesForUser', () => {
       ${[]}                | ${'LEI'} | ${false}
       ${[Role.PrisonUser]} | ${'LIV'} | ${true}
     `('user with roles and caseload: $roles, can see: $visible', ({ roles, caseLoad, visible }) => {
-      const output = getServicesForUser(roles, false, caseLoad, 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, caseLoad, 12345, [], null)
       expect(!!output.find(service => service.heading === 'View COVID units')).toEqual(visible)
     })
   })
@@ -511,7 +513,7 @@ describe('getServicesForUser', () => {
       ${[Role.HpaUser]} | ${true}
       ${[]}             | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Historical Prisoner Application')).toEqual(visible)
     })
   })
@@ -523,7 +525,7 @@ describe('getServicesForUser', () => {
       ${[Role.WorkReadinessView]}                         | ${true}
       ${[]}                                               | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Work after leaving prison')).toEqual(visible)
     })
   })
@@ -537,7 +539,7 @@ describe('getServicesForUser', () => {
       ${[Role.ManageOffencesAdmin]}                                                          | ${true}
       ${[]}                                                                                  | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Manage offences')).toEqual(visible)
     })
   })
@@ -553,7 +555,7 @@ describe('getServicesForUser', () => {
     `(
       'user with activeCaseLoadId: $activeCaseLoadId, can see: $visible',
       ({ activeServices, activeCaseLoadId, visible }) => {
-        const output = getServicesForUser([], false, activeCaseLoadId, 12345, [], activeServices)
+        const output = getServicesForUser([], false, { policies: [] }, activeCaseLoadId, 12345, [], activeServices)
         expect(!!output.find(service => service.heading === 'Learning and work progress')).toEqual(visible)
       },
     )
@@ -565,7 +567,7 @@ describe('getServicesForUser', () => {
       ${[{ app: 'prepareSomeoneForReleaseUi' as ServiceName, activeAgencies: ['LEI'] }]} | ${[Role.ResettlementPassportEdit]} | ${true}
       ${[{ app: 'prepareSomeoneForReleaseUi' as ServiceName, activeAgencies: ['LEI'] }]} | ${[]}                              | ${false}
     `('user with roles: $roles, can see: $visible', ({ activeServices, roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], activeServices)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], activeServices)
       expect(!!output.find(service => service.heading === 'Prepare someone for release')).toEqual(visible)
     })
   })
@@ -576,7 +578,7 @@ describe('getServicesForUser', () => {
       ${[Role.ResettlementPassportEdit]} | ${false}
       ${[]}                              | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'MOR', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'MOR', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Prepare someone for release')).toEqual(visible)
     })
   })
@@ -588,7 +590,7 @@ describe('getServicesForUser', () => {
       ${[]}             | ${[{ app: 'cas2', activeAgencies: ['LEI'] }]} | ${false}
       ${[Role.PomUser]} | ${[{ app: 'cas2', activeAgencies: ['MOR'] }]} | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible, activeServices }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], activeServices)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], activeServices)
       expect(!!output.find(service => service.heading === 'CAS2 - Short-Term Accommodation')).toEqual(visible)
     })
   })
@@ -599,7 +601,7 @@ describe('getServicesForUser', () => {
       ${[]} | ${[{ app: 'alerts', activeAgencies: ['LEI'] }]} | ${true}
       ${[]} | ${[{ app: 'alerts', activeAgencies: ['MOR'] }]} | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible, activeServices }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], activeServices)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], activeServices)
       expect(!!output.find(service => service.heading === 'Alerts')).toEqual(visible)
     })
   })
@@ -610,7 +612,7 @@ describe('getServicesForUser', () => {
       ${[]} | ${[{ app: 'csipApi', activeAgencies: ['LEI'] }]} | ${true}
       ${[]} | ${[{ app: 'csipApi', activeAgencies: ['MOR'] }]} | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible, activeServices }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], activeServices)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], activeServices)
       expect(!!output.find(service => service.heading === 'CSIP')).toEqual(visible)
     })
   })
@@ -621,7 +623,7 @@ describe('getServicesForUser', () => {
       ${[Role.ResettlementPassportEdit]} | ${[{ app: 'prepareSomeoneForReleaseUi', activeAgencies: ['LEI'] }]} | ${true}
       ${[]}                              | ${[{ app: 'prepareSomeoneForReleaseUi', activeAgencies: ['MOR'] }]} | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible, activeServices }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], activeServices)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], activeServices)
       expect(!!output.find(service => service.heading === 'Prepare someone for release')).toEqual(visible)
     })
   })
@@ -660,7 +662,7 @@ describe('getServicesForUser', () => {
   },
 ]}
     `('user with roles: $roles, can see: $visible', ({ roles, visible, activeServices }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], activeServices)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], activeServices)
       expect(!!output.find(service => service.heading === 'Residential locations')).toEqual(visible)
     })
   })
@@ -673,7 +675,7 @@ describe('getServicesForUser', () => {
       ${'AAA'}       | ${true}  | ${[{ app: 'another' as ServiceName, activeAgencies: ['LEI'] }]}
       ${'BBB'}       | ${false} | ${[{ app: 'another' as ServiceName, activeAgencies: ['LEI'] }]}
     `('caseload: $activeCaseLoad, can see: $visible', ({ activeCaseLoad, visible, activeServices }) => {
-      const output = getServicesForUser([], false, activeCaseLoad, 12345, [], activeServices)
+      const output = getServicesForUser([], false, { policies: [] }, activeCaseLoad, 12345, [], activeServices)
       expect(!!output.find(service => service.heading === 'Reporting')).toEqual(visible)
     })
   })
@@ -712,7 +714,7 @@ describe('getServicesForUser', () => {
   },
 ]}
     `('user with roles: $roles, can see: $visible', ({ roles, visible, activeServices }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], activeServices)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], activeServices)
       expect(!!output.find(service => service.heading === 'Incident reporting')).toEqual(visible)
     })
   })
@@ -723,7 +725,7 @@ describe('getServicesForUser', () => {
       ${[]} | ${[{ app: 'caseNotesApi', activeAgencies: ['LEI'] }]} | ${true}
       ${[]} | ${[{ app: 'caseNotesApi', activeAgencies: ['MOR'] }]} | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible, activeServices }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], activeServices)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], activeServices)
       expect(!!output.find(service => service.heading === 'Case Notes API')).toEqual(visible)
     })
   })
@@ -734,7 +736,7 @@ describe('getServicesForUser', () => {
       ${[Role.DietAndAllergiesReport]} | ${true}
       ${[]}                            | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], null)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(!!output.find(service => service.heading === 'Dietary requirements')).toEqual(visible)
     })
   })
@@ -745,7 +747,7 @@ describe('getServicesForUser', () => {
       ${[Role.PrisonUser]} | ${[{ app: 'manageApplications', activeAgencies: ['LEI'] }]} | ${true}
       ${[]}                | ${[{ app: 'manageApplications', activeAgencies: ['MOR'] }]} | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible, activeServices }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], activeServices)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], activeServices)
       expect(!!output.find(service => service.heading === 'Applications')).toEqual(visible)
     })
   })
@@ -756,7 +758,7 @@ describe('getServicesForUser', () => {
       ${[]} | ${[{ app: 'caseNotesApi', activeAgencies: ['LEI'] }]}   | ${true}
       ${[]} | ${[{ app: 'caseNotesApi', activeAgencies: undefined }]} | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible, activeServices }) => {
-      const output = getServicesForUser(roles, false, 'LEI', 12345, [], activeServices)
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], activeServices)
       expect(!!output.find(service => service.heading === 'Case Notes API')).toEqual(visible)
     })
   })
@@ -768,7 +770,7 @@ describe('getServicesForUser', () => {
       [[Role.CreateAnEMOrder], [{ app: ServiceName.CEMO, activeAgencies: ['ANOTHER'] }], 'LEI', false],
       [[Role.CreateAnEMOrder], [{ app: ServiceName.CEMO, activeAgencies: ['LEI'] }], 'LEI', true],
     ])('user with roles %s, can see: %s', (roles, activeServices, activeCaseLoadId, visible) => {
-      const output = getServicesForUser(roles, false, activeCaseLoadId, 12345, [], activeServices)
+      const output = getServicesForUser(roles, false, { policies: [] }, activeCaseLoadId, 12345, [], activeServices)
       expect(
         output.some(service => service.heading === 'Apply, change or end an Electronic Monitoring Order (EMO)'),
       ).toEqual(visible)

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -38,7 +38,7 @@ function isActiveInEstablishmentWithLegacyFallback(
 export default (
   roles: string[],
   isKeyworker: boolean,
-  allocation: StaffAllocationPolicies,
+  allocationPolicies: StaffAllocationPolicies,
   activeCaseLoadId: string,
   staffId: number,
   locations: Location[],
@@ -527,7 +527,7 @@ export default (
       href: `${config.serviceUrls.allocateKeyWorkers.url}/staff-profile/${staffId}`,
       navEnabled: true,
       enabled: () =>
-        userHasRoles([Role.KeyWorker], roles) &&
+        allocationPolicies.policies.includes('KEY_WORKER') &&
         isActiveInEstablishment(activeCaseLoadId, ServiceName.ALLOCATE_KEY_WORKERS, activeServices, false),
     },
     {
@@ -537,7 +537,7 @@ export default (
       href: config.serviceUrls.allocatePersonalOfficers.url,
       navEnabled: true,
       enabled: () =>
-        userHasRoles([Role.PersonalOfficerAllocate, Role.PersonalOfficerView], roles) &&
+        userHasRoles([Role.PersonalOfficerView, Role.PersonalOfficerAllocate], roles) &&
         isActiveInEstablishment(activeCaseLoadId, ServiceName.ALLOCATE_PERSONAL_OFFICERS, activeServices, false),
     },
     {
@@ -547,7 +547,7 @@ export default (
       href: `${config.serviceUrls.allocatePersonalOfficers.url}/staff-profile/${staffId}`,
       navEnabled: true,
       enabled: () =>
-        userHasRoles([Role.PersonalOfficer], roles) &&
+        allocationPolicies.policies.includes('PERSONAL_OFFICER') &&
         isActiveInEstablishment(activeCaseLoadId, ServiceName.ALLOCATE_PERSONAL_OFFICERS, activeServices, false),
     },
   ]

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -3,6 +3,7 @@ import { Role, userHasRoles } from './roles'
 import { Location } from '../../interfaces/location'
 import { Service } from '../../interfaces/Service'
 import { ServiceActiveAgencies, ServiceName } from '../../@types/activeAgencies'
+import { StaffAllocationPolicies } from '../../data/AllocationsApiClient'
 
 const ALL_PRISONS_STRING = '***'
 
@@ -37,6 +38,7 @@ function isActiveInEstablishmentWithLegacyFallback(
 export default (
   roles: string[],
   isKeyworker: boolean,
+  allocation: StaffAllocationPolicies,
   activeCaseLoadId: string,
   staffId: number,
   locations: Location[],
@@ -64,7 +66,9 @@ export default (
       description: 'View your key worker cases.',
       href: `${config.serviceUrls.omic.url}/key-worker/${staffId}`,
       navEnabled: true,
-      enabled: () => isKeyworker,
+      enabled: () =>
+        isKeyworker &&
+        !isActiveInEstablishment(activeCaseLoadId, ServiceName.ALLOCATE_KEY_WORKERS, activeServices, false),
     },
     {
       id: 'manage-prisoner-whereabouts',
@@ -159,7 +163,9 @@ export default (
       description: 'Add and remove key workers from prisoners and manage individuals.',
       href: config.serviceUrls.omic.url,
       navEnabled: true,
-      enabled: () => userHasRoles([Role.OmicAdmin, Role.KeyworkerMonitor], roles),
+      enabled: () =>
+        userHasRoles([Role.OmicAdmin, Role.KeyworkerMonitor], roles) &&
+        !isActiveInEstablishment(activeCaseLoadId, ServiceName.ALLOCATE_KEY_WORKERS, activeServices, false),
     },
     {
       id: 'pom',
@@ -503,6 +509,46 @@ export default (
       enabled: () =>
         userHasRoles([Role.CreateAnEMOrder], roles) &&
         isActiveInEstablishment(activeCaseLoadId, ServiceName.CEMO, activeServices, false),
+    },
+    {
+      id: 'allocate-key-workers',
+      heading: 'Key workers',
+      description: 'Allocate key workers to prisoners and manage key work in your establishment.',
+      href: config.serviceUrls.allocateKeyWorkers.url,
+      navEnabled: true,
+      enabled: () =>
+        userHasRoles([Role.OmicAdmin, Role.KeyworkerMonitor], roles) &&
+        isActiveInEstablishment(activeCaseLoadId, ServiceName.ALLOCATE_KEY_WORKERS, activeServices, false),
+    },
+    {
+      id: 'my-key-worker-allocations',
+      heading: 'My key worker allocations',
+      description: 'View your key worker allocations and personal statistics.',
+      href: `${config.serviceUrls.allocateKeyWorkers.url}/staff-profile/${staffId}`,
+      navEnabled: true,
+      enabled: () =>
+        userHasRoles([Role.KeyWorker], roles) &&
+        isActiveInEstablishment(activeCaseLoadId, ServiceName.ALLOCATE_KEY_WORKERS, activeServices, false),
+    },
+    {
+      id: 'allocate-personal-officers',
+      heading: 'Personal officers',
+      description: 'Allocate personal officers to prisoners and manage officer work in your establishment.',
+      href: config.serviceUrls.allocatePersonalOfficers.url,
+      navEnabled: true,
+      enabled: () =>
+        userHasRoles([Role.PersonalOfficerAllocate, Role.PersonalOfficerView], roles) &&
+        isActiveInEstablishment(activeCaseLoadId, ServiceName.ALLOCATE_PERSONAL_OFFICERS, activeServices, false),
+    },
+    {
+      id: 'my-personal-officer-allocations',
+      heading: 'My personal officer allocations',
+      description: 'View your personal officer allocations and personal statistics.',
+      href: `${config.serviceUrls.allocatePersonalOfficers.url}/staff-profile/${staffId}`,
+      navEnabled: true,
+      enabled: () =>
+        userHasRoles([Role.PersonalOfficer], roles) &&
+        isActiveInEstablishment(activeCaseLoadId, ServiceName.ALLOCATE_PERSONAL_OFFICERS, activeServices, false),
     },
   ]
     .filter(service => service.enabled())

--- a/server/services/utils/roles.ts
+++ b/server/services/utils/roles.ts
@@ -81,6 +81,9 @@ export enum Role {
   IncidentReportingApprove = 'INCIDENT_REPORTS__APPROVE',
   DietAndAllergiesReport = 'DIET_AND_FOOD_ALLERGIES_REPORT',
   CreateAnEMOrder = 'EM_CEMO__CREATE_ORDER',
+  PersonalOfficer = 'PERSONAL_OFFICER',
+  PersonalOfficerView = 'PERSONAL_OFFICER_VIEW',
+  PersonalOfficerAllocate = 'PERSONAL_OFFICER_ALLOCATE',
 }
 export const userHasRoles = (rolesToCheck: string[], userRoles: string[]): boolean => {
   return rolesToCheck.some(role => userRoles.includes(role))

--- a/server/services/utils/roles.ts
+++ b/server/services/utils/roles.ts
@@ -81,7 +81,6 @@ export enum Role {
   IncidentReportingApprove = 'INCIDENT_REPORTS__APPROVE',
   DietAndAllergiesReport = 'DIET_AND_FOOD_ALLERGIES_REPORT',
   CreateAnEMOrder = 'EM_CEMO__CREATE_ORDER',
-  PersonalOfficer = 'PERSONAL_OFFICER',
   PersonalOfficerView = 'PERSONAL_OFFICER_VIEW',
   PersonalOfficerAllocate = 'PERSONAL_OFFICER_ALLOCATE',
 }

--- a/tests/mocks/hmppsUserMock.ts
+++ b/tests/mocks/hmppsUserMock.ts
@@ -68,6 +68,7 @@ export const prisonUserMock: PrisonUser = {
   caseLoads: [activeCaseLoadMock],
   activeCaseLoad: activeCaseLoadMock,
   services: servicesMock,
+  allocationJobResponsibilities: [],
 }
 
 export const hmppsUserMock: HmppsUser = {


### PR DESCRIPTION
This PR adds 4 new services to the service list:
- allocate-key-workers
- my-key-worker-allocations
- allocate-personal-officers
- my-personal-officer-allocations

`allocate-key-workers` and `my-key-worker-allocations` are replacement for `manage-key-workers` and `key-worker-allocations`, therefore for establishment where the new services are enabled, the old services will not disabled.

Additionally, this PR adds `allocationJobResponsibilities` to `PrisonUserAccess`, so that the other services can use `res.locals.user.allocationJobResponsibilities` to identify whether a user has Key worker responsibility and/or Personal officer responsibility.