### PR TITLE
ELM-3183: Setup CEMO tile for all prisons

### DIFF
--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -790,9 +790,9 @@ describe('getServicesForUser', () => {
 
   describe('Create an electronic monitoring order', () => {
     test.each`
-      roles                            | visible
-      ${[Role.DietAndAllergiesReport]} | ${true}
-      ${[]}                            | ${false}
+      roles                     | visible
+      ${[Role.CreateAnEMOrder]} | ${true}
+      ${[]}                     | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
       const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(

--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -789,15 +789,14 @@ describe('getServicesForUser', () => {
   })
 
   describe('Create an electronic monitoring order', () => {
-    test.each([
-      [[], [], 'LEI', false],
-      [[Role.CreateAnEMOrder], [], 'LEI', false],
-      [[Role.CreateAnEMOrder], [{ app: ServiceName.CEMO, activeAgencies: ['ANOTHER'] }], 'LEI', false],
-      [[Role.CreateAnEMOrder], [{ app: ServiceName.CEMO, activeAgencies: ['LEI'] }], 'LEI', true],
-    ])('user with roles %s, can see: %s', (roles, activeServices, activeCaseLoadId, visible) => {
-      const output = getServicesForUser(roles, false, { policies: [] }, activeCaseLoadId, 12345, [], activeServices)
+    test.each`
+      roles                            | visible
+      ${[Role.DietAndAllergiesReport]} | ${true}
+      ${[]}                            | ${false}
+    `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
+      const output = getServicesForUser(roles, false, { policies: [] }, 'LEI', 12345, [], null)
       expect(
-        output.some(service => service.heading === 'Apply, change or end an Electronic Monitoring Order (EMO)'),
+        !!output.find(service => service.heading === 'Apply, change or end an Electronic Monitoring Order (EMO)'),
       ).toEqual(visible)
     })
   })

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -514,9 +514,7 @@ export default (
       description: '',
       href: config.serviceUrls.createAnEMOrder.url,
       navEnabled: true,
-      enabled: () =>
-        userHasRoles([Role.CreateAnEMOrder], roles) &&
-        isActiveInEstablishment(activeCaseLoadId, ServiceName.CEMO, activeServices, false),
+      enabled: () => userHasRoles([Role.CreateAnEMOrder], roles),
     },
     {
       id: 'allocate-key-workers',


### PR DESCRIPTION
Remove active case load id check to make cemo tile available to all user with cemo role