### PR TITLE
RR-1824 - config and new tile for new DPS service "Support for additional needs"

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -61,6 +61,7 @@ ALLOCATE_KEY_WORKERS_API_URL=https://external/allocate-key-worker-api
 ALLOCATE_KEY_WORKERS_UI_URL=https://external/allocate-key-worker-ui
 ALLOCATE_PERSONAL_OFFICERS_API_URL=https://external/allocate-personal-officer-api
 ALLOCATE_PERSONAL_OFFICERS_UI_URL=https://external/allocate-personal-officer-ui
+SUPPORT_ADDITIONAL_NEEDS_URL=https://external/support-additional-needs
 ACTIVITIES_ENABLED_PRISONS=LEI,RSI
 APPOINTMENTS_ENABLED_PRISONS=LEI,RSI
 USE_OF_FORCE_PRISONS=FWI,MDI,WRI

--- a/helm_deploy/hmpps-micro-frontend-components/templates/services-cronjob.yaml
+++ b/helm_deploy/hmpps-micro-frontend-components/templates/services-cronjob.yaml
@@ -50,6 +50,8 @@ spec:
                 value: "{{ index .Values "generic-service" "env" "ALLOCATE_KEY_WORKERS_API_URL" }}"
               - name: ALLOCATE_PERSONAL_OFFICERS_API_URL
                 value: "{{ index .Values "generic-service" "env" "ALLOCATE_PERSONAL_OFFICERS_API_URL" }}"
+              - name: SUPPORT_ADDITIONAL_NEEDS_URL
+                value: "{{ index .Values "generic-service" "env" "SUPPORT_ADDITIONAL_NEEDS_URL" }}"
               - name: REDIS_HOST
                 valueFrom:
                   secretKeyRef:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -77,6 +77,7 @@ generic-service:
     ALLOCATE_KEY_WORKERS_UI_URL: https://allocate-key-workers-dev.hmpps.service.justice.gov.uk/key-worker
     ALLOCATE_PERSONAL_OFFICERS_API_URL: https://keyworker-api-dev.prison.service.justice.gov.uk/PERSONAL_OFFICER
     ALLOCATE_PERSONAL_OFFICERS_UI_URL: https://allocate-key-workers-dev.hmpps.service.justice.gov.uk/personal-officer
+    SUPPORT_ADDITIONAL_NEEDS_URL: https://support-for-additional-needs-dev.hmpps.service.justice.gov.uk
 
     # Feature
     ACTIVITIES_ENABLED_PRISONS: "LEI,RSI,LPI"
@@ -88,6 +89,7 @@ generic-service:
     FEATURE_SERVICES_STORE_ENABLED: true
     ACCREDITED_PROGRAMMES_ENABLED: true
     REPORTING_ENABLED_PRISONS: "***"
+    SUPPORT_ADDITIONAL_NEEDS_ENABLED: true
 
 generic-prometheus-alerts:
   alertSeverity: hmpps-micro-frontend-components-non-prod

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -75,6 +75,7 @@ generic-service:
     ALLOCATE_KEY_WORKERS_UI_URL: https://allocate-key-workers-preprod.hmpps.service.justice.gov.uk/key-worker
     ALLOCATE_PERSONAL_OFFICERS_API_URL: https://keyworker-api-preprod.prison.service.justice.gov.uk/PERSONAL_OFFICER
     ALLOCATE_PERSONAL_OFFICERS_UI_URL: https://allocate-key-workers-preprod.hmpps.service.justice.gov.uk/personal-officer
+    SUPPORT_ADDITIONAL_NEEDS_URL: https://support-for-additional-needs-preprod.hmpps.service.justice.gov.uk
 
     # Feature
     ACTIVITIES_ENABLED_PRISONS: "RSI,LPI"
@@ -86,6 +87,7 @@ generic-service:
     FEATURE_SERVICES_STORE_ENABLED: true
     ACCREDITED_PROGRAMMES_ENABLED: true
     REPORTING_ENABLED_PRISONS: "EXI,BNI,LYI,LYI"
+    SUPPORT_ADDITIONAL_NEEDS_ENABLED: true
 
   allowlist:
     sscl-blackpool: 31.121.5.27/32

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -80,6 +80,7 @@ generic-service:
     ALLOCATE_KEY_WORKERS_UI_URL: https://allocate-key-workers.hmpps.service.justice.gov.uk/key-worker
     ALLOCATE_PERSONAL_OFFICERS_API_URL: https://keyworker-api.prison.service.justice.gov.uk/PERSONAL_OFFICER
     ALLOCATE_PERSONAL_OFFICERS_UI_URL: https://allocate-key-workers.hmpps.service.justice.gov.uk/personal-officer
+    SUPPORT_ADDITIONAL_NEEDS_URL: https://support-for-additional-needs.hmpps.service.justice.gov.uk
 
     # Feature
     ACTIVITIES_ENABLED_PRISONS: "RSI,LPI"
@@ -92,6 +93,7 @@ generic-service:
     ACCREDITED_PROGRAMMES_ENABLED: true
     REPORTING_ENABLED_PRISONS: "EXI,BNI,LYI,LYI"
     MATCH_LEARNER_RECORD_ENABLED: "false"
+    SUPPORT_ADDITIONAL_NEEDS_ENABLED: false
 
   allowlist:
     sscl-blackpool: 31.121.5.27/32

--- a/scripts/getReleaseStatus.js
+++ b/scripts/getReleaseStatus.js
@@ -25,6 +25,7 @@ const endpoints = [
   { application: 'manageApplications', urlEnv: 'MANAGE_APPLICATIONS_URL' },
   { application: 'allocateKeyWorkers', urlEnv: 'ALLOCATE_KEY_WORKERS_API_URL' },
   { application: 'allocatePersonalOfficers', urlEnv: 'ALLOCATE_PERSONAL_OFFICERS_API_URL' },
+  { application: 'supportAdditionalNeeds', urlEnv: 'SUPPORT_ADDITIONAL_NEEDS_URL' },
 ]
 
 function getApplicationInfo(appLabel, url) {

--- a/server/config.ts
+++ b/server/config.ts
@@ -238,6 +238,10 @@ export default {
     allocatePersonalOfficers: {
       url: get('ALLOCATE_PERSONAL_OFFICERS_UI_URL', 'http://localhost:3001', requiredInProduction),
     },
+    supportAdditionalNeeds: {
+      url: get('SUPPORT_ADDITIONAL_NEEDS_URL', 'http://localhost:3001', requiredInProduction),
+      enabled: get('SUPPORT_ADDITIONAL_NEEDS_ENABLED', 'false') === 'true',
+    },
   },
   features: {
     servicesStore: {

--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -54,6 +54,7 @@ jest.mock('../../config', () => ({
     allocateKeyWorkers: { url: 'url' },
     allocatePersonalOfficers: { url: 'url' },
     matchLearnerRecord: { url: 'url', enabled: true },
+    supportAdditionalNeeds: { url: 'url', enabled: true },
   },
 }))
 
@@ -864,5 +865,22 @@ describe('getServicesForUser', () => {
       )
       expect(!!output.find(service => service.heading === 'My personal officer allocations')).toEqual(visible)
     })
+  })
+
+  describe('Support additional needs', () => {
+    test.each`
+      activeServices                                                                 | activeCaseLoadId | visible
+      ${[{ app: 'supportAdditionalNeeds' as ServiceName, activeAgencies: ['LEI'] }]} | ${'LEI'}         | ${true}
+      ${[{ app: 'supportAdditionalNeeds' as ServiceName, activeAgencies: ['***'] }]} | ${'LEI'}         | ${true}
+      ${[{ app: 'supportAdditionalNeeds' as ServiceName, activeAgencies: ['MDI'] }]} | ${'MDI'}         | ${true}
+      ${[{ app: 'supportAdditionalNeeds' as ServiceName, activeAgencies: ['LEI'] }]} | ${'MDI'}         | ${true}
+      ${[]}                                                                          | ${'LEI'}         | ${true}
+    `(
+      'user with activeCaseLoadId: $activeCaseLoadId, can see: $visible',
+      ({ activeServices, activeCaseLoadId, visible }) => {
+        const output = getServicesForUser([], false, { policies: [] }, activeCaseLoadId, 12345, [], activeServices)
+        expect(!!output.find(service => service.heading === 'Support for additional needs')).toEqual(visible)
+      },
+    )
   })
 })

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -567,6 +567,14 @@ export default (
       navEnabled: true,
       enabled: () => config.serviceUrls.matchLearnerRecord.enabled && userHasRoles([Role.MatchLearnerRecord], roles),
     },
+    {
+      id: 'support-additional-needs',
+      heading: 'Support for additional needs',
+      description: 'View and manage support planning for education and life across prison.',
+      href: config.serviceUrls.supportAdditionalNeeds.url,
+      navEnabled: true,
+      enabled: () => config.serviceUrls.supportAdditionalNeeds.enabled,
+    },
   ]
     .filter(service => service.enabled())
     .map(service => {

--- a/tests/setEnvVars.js
+++ b/tests/setEnvVars.js
@@ -10,3 +10,5 @@ process.env.CASE_NOTES_API_URL = 'https://dev.offender-case-notes.service.justic
 process.env.PREPARE_SOMEONE_FOR_RELEASE_URL = 'https://resettlement-passport-ui-dev.hmpps.service.justice.gov.uk'
 process.env.CEMO_URL = 'https://hmpps-electronic-monitoring-create-an-order-dev.hmpps.service.justice.gov.uk'
 process.env.MANAGE_APPLICATIONS_URL = 'https://managing-prisoner-apps-staff-dev.hmpps.service.justice.gov.uk'
+process.env.SUPPORT_ADDITIONAL_NEEDS_URL =
+  'https://https://support-for-additional-needs-dev.hmpps.service.justice.gov.uk'


### PR DESCRIPTION
This PR adds the new tile for the new DPS service "Support for additional needs"

In this PR it is set to be enabled in `dev` and `preprod`, but not enabled in `prod`

Support for additional needs (SAN) goes live on 01/10/25, so I will raise another PR nearer the time to enable it in `prod`