### PR TITLE
CDPS-1620: Bring linting closer in line with HMPPS template

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020-2021 Crown Copyright (Ministry of Justice)
+Copyright (c) 2020-2025 Crown Copyright (Ministry of Justice)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,40 +1,6 @@
 import hmppsConfig from '@ministryofjustice/eslint-config-hmpps'
-// eslint-disable-next-line import/no-extraneous-dependencies
-import typescriptEslint from '@typescript-eslint/eslint-plugin'
 
-const ignorePaths = ['node_modules', 'public', 'assets', 'cypress.json', 'reporter-config.json', 'dist/', 'scripts/']
-
-const defaultConfig = hmppsConfig({
-  extraIgnorePaths: [
-    'integration_tests/parent_app/',
-    ...ignorePaths.map(path => `integration_tests/${path}`),
-    ...ignorePaths.map(path => `${path}`),
-  ],
+const ignorePaths = ['assets/', 'dist/', 'scripts/']
+export default hmppsConfig({
+  extraIgnorePaths: [...ignorePaths.map(path => `integration_tests/${path}`), ...ignorePaths.map(path => `${path}`)],
 })
-
-defaultConfig.push({
-  rules: {
-    'import/prefer-default-export': 'off',
-    'dot-notation': 'off',
-  },
-})
-
-defaultConfig.push({
-  plugins: {
-    '@typescript-eslint': typescriptEslint,
-  },
-  rules: {
-    'import/prefer-default-export': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
-    '@typescript-eslint/no-unused-vars': [
-      1,
-      {
-        argsIgnorePattern: 'res|next|^err|_',
-        ignoreRestSiblings: true,
-        caughtErrorsIgnorePattern: '^_',
-      },
-    ],
-  },
-})
-
-export default defaultConfig

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
       },
       "devDependencies": {
         "@jgoz/esbuild-plugin-typecheck": "^4.0.3",
-        "@ministryofjustice/eslint-config-hmpps": "^0.0.3",
+        "@ministryofjustice/eslint-config-hmpps": "^0.0.5",
         "@ministryofjustice/hmpps-precommit-hooks": "^0.0.3",
         "@tsconfig/node22": "^22.0.2",
         "@types/bunyan": "^1.8.11",
@@ -84,7 +84,6 @@
         "esbuild-plugin-copy": "^2.1.1",
         "esbuild-plugin-manifest": "^1.0.5",
         "esbuild-sass-plugin": "^3.3.1",
-        "eslint-import-resolver-typescript": "^4.4.4",
         "glob": "^11.0.3",
         "jest": "^30.1.1",
         "jest-html-reporter": "^4.3.0",
@@ -941,9 +940,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1093,9 +1092,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.33.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.33.0.tgz",
-      "integrity": "sha512-5K1/mKhWaMfreBGJTwval43JJmkip0RmM+3+IuqupeSKNC/Th2Kc7ucaq5ovTSra/OOKB9c58CGSz3QMVbWt0A==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.36.0.tgz",
+      "integrity": "sha512-uhCbYtYynH30iZErszX78U+nR3pJU3RHGQ57NXy5QupD4SBVwDeU8TNBy+MjMngc1UyIW9noKqsRqfjQTBU2dw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1920,21 +1919,21 @@
       "integrity": "sha512-2IHAOaLauc8qaAitvWS+U931T+ze+7MNWrDHY47IENP5y2UA0vqJDu67kWZDdpCN1fFC77sfgfB+HV7SrKshnQ=="
     },
     "node_modules/@ministryofjustice/eslint-config-hmpps": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@ministryofjustice/eslint-config-hmpps/-/eslint-config-hmpps-0.0.3.tgz",
-      "integrity": "sha512-ZAdcbzHfxr8uXXJ2vvrzxItKrgLYerz8ijcHVmaB5fM7ba3nZnAMcwx6qnyQbz2AvXsyVWXRuKX+/ctz0k9HXg==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@ministryofjustice/eslint-config-hmpps/-/eslint-config-hmpps-0.0.5.tgz",
+      "integrity": "sha512-+X/Mu4qB/AzSX31yPSQXtSTXQMqsF+3w0nEOMeMFDu/dx2Ql2Rds6ZX3OE1P4LTgLB+ynnDnZY/CkRsw8YAkVg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "^9.32.0",
-        "@typescript-eslint/eslint-plugin": "^8.39.0",
-        "@typescript-eslint/parser": "^8.39.0",
+        "@eslint/js": "^9.35.0",
+        "@typescript-eslint/eslint-plugin": "^8.42.0",
+        "@typescript-eslint/parser": "^8.42.0",
         "confusing-browser-globals": "^1.0.11",
-        "eslint": "^9.32.0",
+        "eslint": "^9.35.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-import-resolver-typescript": "^4.4.4",
-        "eslint-plugin-cypress": "^5.1.0",
+        "eslint-plugin-cypress": "^5.1.1",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-no-only-tests": "^3.3.0",
         "eslint-plugin-prettier": "^5.5.4",
@@ -1946,19 +1945,6 @@
       },
       "engines": {
         "node": "20 || 22"
-      }
-    },
-    "node_modules/@ministryofjustice/eslint-config-hmpps/node_modules/eslint-plugin-cypress": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-5.1.0.tgz",
-      "integrity": "sha512-tdLXm4aq9vX2hTtKJTUFD3gdNseMKqsf8+P6hI4TtOPdz1LU4xvTpQBd1++qPAsPZP2lyYh71B5mvzu2lBr4Ow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "globals": "^16.2.0"
-      },
-      "peerDependencies": {
-        "eslint": ">=9"
       }
     },
     "node_modules/@ministryofjustice/frontend": {
@@ -2801,17 +2787,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.40.0.tgz",
-      "integrity": "sha512-w/EboPlBwnmOBtRbiOvzjD+wdiZdgFeo17lkltrtn7X37vagKKWJABvyfsJXTlHe6XBzugmYgd4A4nW+k8Mixw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.1.tgz",
+      "integrity": "sha512-molgphGqOBT7t4YKCSkbasmu1tb1MgrZ2szGzHbclF7PNmOkSTQVHy+2jXOSnxvR3+Xe1yySHFZoqMpz3TfQsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.40.0",
-        "@typescript-eslint/type-utils": "8.40.0",
-        "@typescript-eslint/utils": "8.40.0",
-        "@typescript-eslint/visitor-keys": "8.40.0",
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/type-utils": "8.44.1",
+        "@typescript-eslint/utils": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -2825,7 +2811,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.40.0",
+        "@typescript-eslint/parser": "^8.44.1",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <6.0.0"
       }
@@ -2841,16 +2827,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.40.0.tgz",
-      "integrity": "sha512-jCNyAuXx8dr5KJMkecGmZ8KI61KBUhkCob+SD+C+I5+Y1FWI2Y3QmY4/cxMCC5WAsZqoEtEETVhUiUMIGCf6Bw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.1.tgz",
+      "integrity": "sha512-EHrrEsyhOhxYt8MTg4zTF+DJMuNBzWwgvvOYNj/zm1vnaD/IC5zCXFehZv94Piqa2cRFfXrTFxIvO95L7Qc/cw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.40.0",
-        "@typescript-eslint/types": "8.40.0",
-        "@typescript-eslint/typescript-estree": "8.40.0",
-        "@typescript-eslint/visitor-keys": "8.40.0",
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2866,14 +2852,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.40.0.tgz",
-      "integrity": "sha512-/A89vz7Wf5DEXsGVvcGdYKbVM9F7DyFXj52lNYUDS1L9yJfqjW/fIp5PgMuEJL/KeqVTe2QSbXAGUZljDUpArw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.1.tgz",
+      "integrity": "sha512-ycSa60eGg8GWAkVsKV4E6Nz33h+HjTXbsDT4FILyL8Obk5/mx4tbvCNsLf9zret3ipSumAOG89UcCs/KRaKYrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.40.0",
-        "@typescript-eslint/types": "^8.40.0",
+        "@typescript-eslint/tsconfig-utils": "^8.44.1",
+        "@typescript-eslint/types": "^8.44.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -2888,14 +2874,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.40.0.tgz",
-      "integrity": "sha512-y9ObStCcdCiZKzwqsE8CcpyuVMwRouJbbSrNuThDpv16dFAj429IkM6LNb1dZ2m7hK5fHyzNcErZf7CEeKXR4w==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.1.tgz",
+      "integrity": "sha512-NdhWHgmynpSvyhchGLXh+w12OMT308Gm25JoRIyTZqEbApiBiQHD/8xgb6LqCWCFcxFtWwaVdFsLPQI3jvhywg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.40.0",
-        "@typescript-eslint/visitor-keys": "8.40.0"
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2906,9 +2892,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.40.0.tgz",
-      "integrity": "sha512-jtMytmUaG9d/9kqSl/W3E3xaWESo4hFDxAIHGVW/WKKtQhesnRIJSAJO6XckluuJ6KDB5woD1EiqknriCtAmcw==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.1.tgz",
+      "integrity": "sha512-B5OyACouEjuIvof3o86lRMvyDsFwZm+4fBOqFHccIctYgBjqR3qT39FBYGN87khcgf0ExpdCBeGKpKRhSFTjKQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2923,15 +2909,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.40.0.tgz",
-      "integrity": "sha512-eE60cK4KzAc6ZrzlJnflXdrMqOBaugeukWICO2rB0KNvwdIMaEaYiywwHMzA1qFpTxrLhN9Lp4E/00EgWcD3Ow==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.1.tgz",
+      "integrity": "sha512-KdEerZqHWXsRNKjF9NYswNISnFzXfXNDfPxoTh7tqohU/PRIbwTmsjGK6V9/RTYWau7NZvfo52lgVk+sJh0K3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.40.0",
-        "@typescript-eslint/typescript-estree": "8.40.0",
-        "@typescript-eslint/utils": "8.40.0",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1",
+        "@typescript-eslint/utils": "8.44.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -2948,9 +2934,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.40.0.tgz",
-      "integrity": "sha512-ETdbFlgbAmXHyFPwqUIYrfc12ArvpBhEVgGAxVYSwli26dn8Ko+lIo4Su9vI9ykTZdJn+vJprs/0eZU0YMAEQg==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.1.tgz",
+      "integrity": "sha512-Lk7uj7y9uQUOEguiDIDLYLJOrYHQa7oBiURYVFqIpGxclAFQ78f6VUOM8lI2XEuNOKNB7XuvM2+2cMXAoq4ALQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2962,16 +2948,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.40.0.tgz",
-      "integrity": "sha512-k1z9+GJReVVOkc1WfVKs1vBrR5MIKKbdAjDTPvIK3L8De6KbFfPFt6BKpdkdk7rZS2GtC/m6yI5MYX+UsuvVYQ==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.1.tgz",
+      "integrity": "sha512-qnQJ+mVa7szevdEyvfItbO5Vo+GfZ4/GZWWDRRLjrxYPkhM+6zYB2vRYwCsoJLzqFCdZT4mEqyJoyzkunsZ96A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.40.0",
-        "@typescript-eslint/tsconfig-utils": "8.40.0",
-        "@typescript-eslint/types": "8.40.0",
-        "@typescript-eslint/visitor-keys": "8.40.0",
+        "@typescript-eslint/project-service": "8.44.1",
+        "@typescript-eslint/tsconfig-utils": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/visitor-keys": "8.44.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -2991,16 +2977,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.40.0.tgz",
-      "integrity": "sha512-Cgzi2MXSZyAUOY+BFwGs17s7ad/7L+gKt6Y8rAVVWS+7o6wrjeFN4nVfTpbE25MNcxyJ+iYUXflbs2xR9h4UBg==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.1.tgz",
+      "integrity": "sha512-DpX5Fp6edTlocMCwA+mHY8Mra+pPjRZ0TfHkXI8QFelIKcbADQz1LUPNtzOFUriBB2UYqw4Pi9+xV4w9ZczHFg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.40.0",
-        "@typescript-eslint/types": "8.40.0",
-        "@typescript-eslint/typescript-estree": "8.40.0"
+        "@typescript-eslint/scope-manager": "8.44.1",
+        "@typescript-eslint/types": "8.44.1",
+        "@typescript-eslint/typescript-estree": "8.44.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3015,13 +3001,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.40.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.40.0.tgz",
-      "integrity": "sha512-8CZ47QwalyRjsypfwnbI3hKy5gJDPmrkLjkgMxhi0+DZZ2QNx2naS6/hWoVYUHU7LU2zleF68V9miaVZvhFfTA==",
+      "version": "8.44.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.1.tgz",
+      "integrity": "sha512-576+u0QD+Jp3tZzvfRfxon0EA2lzcDt3lhUbsC6Lgzy9x2VR4E+JUiNyGHi5T8vk0TV+fpJ5GLG1JsJuWCaKhw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.40.0",
+        "@typescript-eslint/types": "8.44.1",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -5668,19 +5654,19 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.33.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.33.0.tgz",
-      "integrity": "sha512-TS9bTNIryDzStCpJN93aC5VRSW3uTx9sClUn4B87pwiCaJh220otoI0X8mJKr+VcPtniMdN8GKjlwgWGUv5ZKA==",
+      "version": "9.36.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.36.0.tgz",
+      "integrity": "sha512-hB4FIzXovouYzwzECDcUkJ4OcfOEkXTv2zRY6B9bkwjx/cprAq0uvm1nl7zvQ0/TsUk0zQiN4uPfJpB9m+rPMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.21.0",
         "@eslint/config-helpers": "^0.3.1",
         "@eslint/core": "^0.15.2",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.33.0",
+        "@eslint/js": "9.36.0",
         "@eslint/plugin-kit": "^0.3.5",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -5852,6 +5838,19 @@
         "ms": "^2.1.1"
       }
     },
+    "node_modules/eslint-plugin-cypress": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-cypress/-/eslint-plugin-cypress-5.1.1.tgz",
+      "integrity": "sha512-LxTmZf1LLh9EklZBVvKNEZj71X9tCJnlYDviAJGsOgEVc6jz+tBODSpm02CS/9eJOfRqGsmVyvIw7LHXQ13RaA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "globals": "^16.2.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=9"
+      }
+    },
     "node_modules/eslint-plugin-import": {
       "version": "2.32.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
@@ -6002,6 +6001,7 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -7126,7 +7126,8 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/graphql": {
       "version": "16.8.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "getAppsStatus": "node -e 'require(\"./scripts/getReleaseStatus\").getData()'",
     "postinstall": "npx patch-package",
     "precommit:secrets": "gitleaks git --pre-commit --redact --staged --verbose --config .gitleaks/config.toml",
-    "precommit:lint": "node_modules/.bin/lint-staged",
+    "precommit:lint": "lint-staged",
     "precommit:verify": "npm run typecheck && npm test"
   },
   "engines": {
@@ -126,7 +126,7 @@
   },
   "devDependencies": {
     "@jgoz/esbuild-plugin-typecheck": "^4.0.3",
-    "@ministryofjustice/eslint-config-hmpps": "^0.0.3",
+    "@ministryofjustice/eslint-config-hmpps": "^0.0.5",
     "@ministryofjustice/hmpps-precommit-hooks": "^0.0.3",
     "@tsconfig/node22": "^22.0.2",
     "@types/bunyan": "^1.8.11",
@@ -158,7 +158,6 @@
     "esbuild-plugin-copy": "^2.1.1",
     "esbuild-plugin-manifest": "^1.0.5",
     "esbuild-sass-plugin": "^3.3.1",
-    "eslint-import-resolver-typescript": "^4.4.4",
     "glob": "^11.0.3",
     "jest": "^30.1.1",
     "jest-html-reporter": "^4.3.0",

--- a/scripts/getReleaseStatus.test.js
+++ b/scripts/getReleaseStatus.test.js
@@ -1,6 +1,6 @@
 const nock = require('nock')
-const { getData } = require('./getReleaseStatus')
 const { mockRedisClientMock } = require('redis')
+const { getData } = require('./getReleaseStatus')
 
 const residentialLocationUrl = 'https://locations-inside-prison-api-dev.hmpps.service.justice.gov.uk'
 const reportingUrl = 'https://digital-prison-reporting-mi-ui-dev.hmpps.service.justice.gov.uk'
@@ -67,7 +67,6 @@ describe('Get release status script', () => {
   })
 
   it('should get application info for all apps', async () => {
-    const { mockRedisClientMock } = require('redis')
     setMockSuccess(allUrls)
 
     await getData()
@@ -92,7 +91,6 @@ describe('Get release status script', () => {
   })
 
   it('should store the data it gets if others fail', async () => {
-    const { mockRedisClientMock } = require('redis')
     const [residentialLocationUrl, ...restUrls] = allUrls
     setMockSuccess([residentialLocationUrl])
     setMockError(restUrls, 404)
@@ -106,7 +104,6 @@ describe('Get release status script', () => {
   })
 
   it('should not fail if it cant find the data in response', async () => {
-    const { mockRedisClientMock } = require('redis')
     const [residentialLocationUrl, ...restUrls] = allUrls
     setMockSuccess([residentialLocationUrl], { some: 'stuff' })
     setMockSuccess(restUrls)
@@ -131,7 +128,6 @@ describe('Get release status script', () => {
   })
 
   it('should not check apps which have had the info check disabled', async () => {
-    const { mockRedisClientMock } = require('redis')
     setMockSuccess(allUrls)
     process.env.INFO_DISABLED_APPS = 'alerts,whereabouts'
 
@@ -156,7 +152,6 @@ describe('Get release status script', () => {
 
   describe('when redis is available', () => {
     it('should use the stored data if it exists and no new data', async () => {
-      const { mockRedisClientMock } = require('redis')
       setMockError(allUrls, 500)
 
       const storedData = [{ app: 'adjudications', activeAgencies: ['agency1', 'agency2'] }]
@@ -168,7 +163,6 @@ describe('Get release status script', () => {
     })
 
     it('should use the stored data for app if it exists and no new data', async () => {
-      const { mockRedisClientMock } = require('redis')
       const storedData = [
         { app: 'adjudications', activeAgencies: ['agency1', 'agency2'] },
         { app: 'activities', activeAgencies: ['agency1', 'agency2'] },
@@ -210,7 +204,6 @@ describe('Get release status script', () => {
     })
 
     it('should use the stored data for app with the info check disabled', async () => {
-      const { mockRedisClientMock } = require('redis')
       process.env.INFO_DISABLED_APPS = 'alerts,whereabouts'
       const storedData = [
         { app: 'adjudications', activeAgencies: ['agency1', 'agency2'] },
@@ -253,7 +246,6 @@ describe('Get release status script', () => {
     })
 
     it('should use new app data if it does not exist on stored data', async () => {
-      const { mockRedisClientMock } = require('redis')
       const storedData = [{ app: 'residentialLocations', activeAgencies: ['agency1', 'agency2'] }]
 
       const [residentialLocationUrl, ...restUrls] = allUrls

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -45,3 +45,5 @@ export const systemTokenBuilder =
 
     return newToken.body.access_token
   }
+
+export default { systemTokenBuilder }

--- a/server/routes/developRoutes.ts
+++ b/server/routes/developRoutes.ts
@@ -15,14 +15,14 @@ export default function developRoutes(services: Services): Router {
   router.use(authorisationMiddleware())
   router.use(auth.authenticationMiddleware(tokenVerifier))
 
-  router.get('/', (req, res, next) => {
+  router.get('/', (_req, res) => {
     res.render('pages/index', { components: AVAILABLE_COMPONENTS })
   })
 
   router.get(
     '/header',
     populateCurrentUser(services.userService),
-    asyncMiddleware(async (req, res, next) => {
+    asyncMiddleware(async (_req, res) => {
       const viewModel = await controller.getHeaderViewModel(res.locals.user)
       return res.render('pages/componentPreview', viewModel)
     }),
@@ -31,7 +31,7 @@ export default function developRoutes(services: Services): Router {
   router.get(
     '/footer',
     populateCurrentUser(services.userService),
-    asyncMiddleware(async (req, res, next) => {
+    asyncMiddleware(async (_req, res) => {
       const viewModel = await controller.getFooterViewModel(res.locals.user)
       return res.render('pages/componentPreview', viewModel)
     }),

--- a/server/services/contentfulService.test.ts
+++ b/server/services/contentfulService.test.ts
@@ -15,9 +15,7 @@ describe('ContentfulService', () => {
   })
 
   it('should get managed pages', async () => {
-    const apolloSpy = jest
-      .spyOn<any, string>(contentfulService['apolloClient'], 'query')
-      .mockResolvedValue(managedPagesCollectionMock)
+    const apolloSpy = jest.spyOn(contentfulService.apolloClient, 'query').mockResolvedValue(managedPagesCollectionMock)
 
     const pages = await contentfulService.getManagedPages()
 

--- a/server/services/contentfulService.ts
+++ b/server/services/contentfulService.ts
@@ -3,7 +3,7 @@ import { ManagedPageLink, ManagedPagesQuery } from '../interfaces/managedPage'
 import config from '../config'
 
 export default class ContentfulService {
-  constructor(private readonly apolloClient: ApolloClient) {}
+  constructor(readonly apolloClient: ApolloClient) {}
 
   /**
    * Get list of `managedPage` links.

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -35,6 +35,7 @@ function isActiveInEstablishmentWithLegacyFallback(
 
   return isActiveInEstablishment(activeCaseLoadId, service, activeServices, legacyFallbackEnabled)
 }
+
 export default (
   roles: string[],
   allocationPolicies: StaffAllocationPolicies,

--- a/server/utils/errorHelpers.ts
+++ b/server/utils/errorHelpers.ts
@@ -1,14 +1,18 @@
 /*
   The errors we get sometimes have the status in .status but also can the status on .responseStatus.
-  As a result we need to handle both in the same way as an "any" type to prevent type errors where 
+  As a result we need to handle both in the same way as an "any" type to prevent type errors where
   there's no overlap.
 */
-export const getErrorStatus = (error: any): number | undefined => {
-  if (error.status) return error.status
-  if (error.responseStatus) return error.responseStatus
+export const getErrorStatus = (error: object): number | undefined => {
+  if ('status' in error && typeof error.status === 'number') {
+    return error.status
+  }
+  if ('responseStatus' in error && typeof error.responseStatus === 'number') {
+    return error.responseStatus
+  }
   return undefined
 }
 
-export const errorHasStatus = (error: any, status: number): boolean => {
+export const errorHasStatus = (error: object, status: number): boolean => {
   return getErrorStatus(error) === status
 }

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -32,6 +32,7 @@ export const assetMap = (url: string) => {
   try {
     const assetMetadataPath = path.resolve(__dirname, '../../assets/manifest.json')
     assetManifest = JSON.parse(fs.readFileSync(assetMetadataPath, 'utf8'))
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
   } catch (_e) {
     logger.error('Could not read asset manifest file')
   }

--- a/tests/mocks/TokenDataMock.ts
+++ b/tests/mocks/TokenDataMock.ts
@@ -18,3 +18,5 @@ export const getTokenDataMock = (overrides: Partial<TokenData> = {}): TokenData 
     ...overrides,
   }
 }
+
+export default { getTokenDataMock }

--- a/tests/mocks/prisonApiClientMock.ts
+++ b/tests/mocks/prisonApiClientMock.ts
@@ -1,3 +1,5 @@
 export const prisonApiClientMock = () => ({
   getUserCaseLoads: jest.fn(),
 })
+
+export default { prisonApiClientMock }


### PR DESCRIPTION
- removed eslint overrides to the shared HMPPS config – this is the cause of all subsequent changes to appease `eslint` and `tsc`
- the `any` type is to be avoided so more type annotations and assertions are needed in a bunch of places; particularly tests
- normalised `default` exports to stop eslint complaining, but imports are still all the same
- these changes lead to only one meaningful difference in the transpiled javascript; i’ve avoided logic changes
    - ⚠️ from what i can tell, `activeCaseLoadId` is not present on the user object is res.locals, even for prison users (i checked Application Insights). i’ve left a TODO note in the code because i felt that changing user managing middleware was beyond the scope of this PR
- a private class property needs to be made public given that tests access it – it’s arguably hacky accessing a private item in the first place and typescript could in future make it [literally inaccessible](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_elements)