### PR TITLE
IR-1240 Allow access to IRS service when conditions are met

### DIFF
--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -493,7 +493,7 @@ export default (
       enabled: () =>
         (userHasRoles([Role.IncidentReportingRO, Role.IncidentReportingRW, Role.IncidentReportingApprove], roles) &&
           isActiveInEstablishment(activeCaseLoadId, ServiceName.INCIDENT_REPORTING, activeServices, false)) ||
-        (userHasRoles([Role.IncidentReportingPECS], roles) &&
+        (userHasRoles([Role.IncidentReportingPECS, Role.IncidentReportingApprove], roles) &&
           isActiveInAgencies(['NORTH', 'SOUTH'], ServiceName.INCIDENT_REPORTING, activeServices)) ||
         (userHasRoles([Role.IncidentReportingApprove], roles) &&
           isHasAnyActiveAgency(ServiceName.INCIDENT_REPORTING, activeServices)),

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -24,10 +24,7 @@ function isActiveInEstablishment(
   )
 }
 
-function isHasAnyActiveAgency(
-  service: ServiceName,
-  activeServices: ServiceActiveAgencies[] | null,
-): boolean | undefined {
+function hasAnyActiveAgency(service: ServiceName, activeServices: ServiceActiveAgencies[] | null): boolean | undefined {
   if (!activeServices) return false // no stored data
   const applicationAgencyConfig = activeServices.find(activeService => activeService.app === service)
   if (!applicationAgencyConfig) return false // no stored data for this service
@@ -496,7 +493,7 @@ export default (
         (userHasRoles([Role.IncidentReportingPECS, Role.IncidentReportingApprove], roles) &&
           isActiveInAgencies(['NORTH', 'SOUTH'], ServiceName.INCIDENT_REPORTING, activeServices)) ||
         (userHasRoles([Role.IncidentReportingApprove], roles) &&
-          isHasAnyActiveAgency(ServiceName.INCIDENT_REPORTING, activeServices)),
+          hasAnyActiveAgency(ServiceName.INCIDENT_REPORTING, activeServices)),
     },
     {
       id: 'manage-applications',

--- a/server/services/utils/roles.ts
+++ b/server/services/utils/roles.ts
@@ -78,6 +78,7 @@ export enum Role {
   IncidentReportingRO = 'INCIDENT_REPORTS__RO',
   IncidentReportingRW = 'INCIDENT_REPORTS__RW',
   IncidentReportingApprove = 'INCIDENT_REPORTS__APPROVE',
+  IncidentReportingPECS = 'INCIDENT_REPORTS__PECS',
   DietAndAllergiesReport = 'DIET_AND_FOOD_ALLERGIES_REPORT',
   CreateAnEMOrder = 'EM_CEMO__CREATE_ORDER',
   PersonalOfficerView = 'PERSONAL_OFFICER_VIEW',


### PR DESCRIPTION
- This pull request enables access to the IRS service for users who have the approval role, provided that the PECS setting is enabled or any other agency setting is active.  
- Implementation includes conditional checks to ensure role and configuration-based restrictions are properly applied.  

- New Utility Functions:
  - Added isHasAnyActiveAgency to check if a service has any active agency configurations.
  - Added isActiveInAgencies to confirm activity in specific agencies based on a given list.
- Enhancements in Service Activation Logic:
  - Updated activation rules for the "Incident Reporting" service to include additional conditions for role verification and agency checks.
- Roles Update:
  - Introduced a new role, IncidentReportingPECS, to support additional user access functionality.

### Checklist  

- [ ] Relevant parties have been informed of updates