### PR TITLE
CDPS-1394: Express 5 compatibility

### DIFF
--- a/integration_tests/server/middleware/asyncMiddleware.ts
+++ b/integration_tests/server/middleware/asyncMiddleware.ts
@@ -1,7 +1,0 @@
-import type { Request, Response, NextFunction, RequestHandler } from 'express'
-
-export default function asyncMiddleware(fn: RequestHandler) {
-  return (req: Request, res: Response, next: NextFunction): void => {
-    Promise.resolve(fn(req, res, next)).catch(next)
-  }
-}

--- a/integration_tests/server/middleware/authorisationMiddleware.ts
+++ b/integration_tests/server/middleware/authorisationMiddleware.ts
@@ -2,10 +2,9 @@ import { jwtDecode } from 'jwt-decode'
 import type { RequestHandler } from 'express'
 
 import logger from '../../logger'
-import asyncMiddleware from './asyncMiddleware'
 
 export default function authorisationMiddleware(authorisedRoles: string[] = []): RequestHandler {
-  return asyncMiddleware((req, res, next) => {
+  return (req, res, next) => {
     // authorities in the user token will always be prefixed by ROLE_.
     // Convert roles that are passed into this function without the prefix so that we match correctly.
     const authorisedAuthorities = authorisedRoles.map(role => (role.startsWith('ROLE_') ? role : `ROLE_${role}`))
@@ -22,5 +21,5 @@ export default function authorisationMiddleware(authorisedRoles: string[] = []):
 
     req.session.returnTo = req.originalUrl
     return res.redirect('/sign-in')
-  })
+  }
 }

--- a/integration_tests/server/routes/index.ts
+++ b/integration_tests/server/routes/index.ts
@@ -1,13 +1,11 @@
-import { type RequestHandler, Router } from 'express'
+import { Router } from 'express'
 
 import type { Services } from '../services'
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-export default function routes(service: Services): Router {
+export default function routes(_service: Services): Router {
   const router = Router()
-  const get = (path: string | string[], handler: RequestHandler) => router.get(path, handler)
 
-  get('/', (req, res, next) => {
+  router.get('/', (_req, res) => {
     res.render('pages/index')
   })
 

--- a/integration_tests/server/routes/index.ts
+++ b/integration_tests/server/routes/index.ts
@@ -1,12 +1,11 @@
 import { type RequestHandler, Router } from 'express'
 
-import asyncMiddleware from '../middleware/asyncMiddleware'
 import type { Services } from '../services'
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default function routes(service: Services): Router {
   const router = Router()
-  const get = (path: string | string[], handler: RequestHandler) => router.get(path, asyncMiddleware(handler))
+  const get = (path: string | string[], handler: RequestHandler) => router.get(path, handler)
 
   get('/', (req, res, next) => {
     res.render('pages/index')

--- a/server/middleware/asyncMiddleware.ts
+++ b/server/middleware/asyncMiddleware.ts
@@ -1,7 +1,0 @@
-import type { Request, Response, NextFunction, RequestHandler } from 'express'
-
-export default function asyncMiddleware(fn: RequestHandler) {
-  return (req: Request, res: Response, next: NextFunction): void => {
-    Promise.resolve(fn(req, res, next)).catch(next)
-  }
-}

--- a/server/middleware/authorisationMiddleware.ts
+++ b/server/middleware/authorisationMiddleware.ts
@@ -2,10 +2,9 @@ import { jwtDecode } from 'jwt-decode'
 import type { RequestHandler } from 'express'
 
 import logger from '../../logger'
-import asyncMiddleware from './asyncMiddleware'
 
 export default function authorisationMiddleware(authorisedRoles: string[] = []): RequestHandler {
-  return asyncMiddleware((req, res, next) => {
+  return (req, res, next) => {
     if (res.locals?.user?.token) {
       const { authorities: roles = [] } = jwtDecode(res.locals.user.token) as { authorities?: string[] }
 
@@ -20,5 +19,5 @@ export default function authorisationMiddleware(authorisedRoles: string[] = []):
     req.session.returnTo = req.originalUrl
     logger.info(`authorisationMiddleware: token = ${res.locals?.user?.token}`)
     return res.redirect('/develop/sign-in')
-  })
+  }
 }

--- a/server/routes/developRoutes.ts
+++ b/server/routes/developRoutes.ts
@@ -1,6 +1,5 @@
 import { Router } from 'express'
 import { Services } from '../services'
-import asyncMiddleware from '../middleware/asyncMiddleware'
 import authorisationMiddleware from '../middleware/authorisationMiddleware'
 import { AVAILABLE_COMPONENTS } from '../@types/AvailableComponent'
 import auth from '../authentication/auth'
@@ -19,23 +18,15 @@ export default function developRoutes(services: Services): Router {
     res.render('pages/index', { components: AVAILABLE_COMPONENTS })
   })
 
-  router.get(
-    '/header',
-    populateCurrentUser(services.userService),
-    asyncMiddleware(async (_req, res) => {
-      const viewModel = await controller.getHeaderViewModel(res.locals.user)
-      return res.render('pages/componentPreview', viewModel)
-    }),
-  )
+  router.get('/header', populateCurrentUser(services.userService), async (_req, res) => {
+    const viewModel = await controller.getHeaderViewModel(res.locals.user)
+    return res.render('pages/componentPreview', viewModel)
+  })
 
-  router.get(
-    '/footer',
-    populateCurrentUser(services.userService),
-    asyncMiddleware(async (_req, res) => {
-      const viewModel = await controller.getFooterViewModel(res.locals.user)
-      return res.render('pages/componentPreview', viewModel)
-    }),
-  )
+  router.get('/footer', populateCurrentUser(services.userService), async (_req, res) => {
+    const viewModel = await controller.getFooterViewModel(res.locals.user)
+    return res.render('pages/componentPreview', viewModel)
+  })
 
   return router
 }


### PR DESCRIPTION
`asyncMiddleware` is not needed since express 5 can already deal with thrown exceptions inside request handlers. cf. [template project](https://github.com/ministryofjustice/hmpps-template-typescript/pull/560) removed it during the upgrade