### PR TITLE
Updated Social visits service name

### DIFF
--- a/server/services/utils/getServicesForUser.test.ts
+++ b/server/services/utils/getServicesForUser.test.ts
@@ -306,14 +306,14 @@ describe('getServicesForUser', () => {
     })
   })
 
-  describe('Manage prison visits', () => {
+  describe('Social visits', () => {
     test.each`
       roles                        | visible
       ${[Role.ManagePrisonVisits]} | ${true}
       ${[]}                        | ${false}
     `('user with roles: $roles, can see: $visible', ({ roles, visible }) => {
       const output = getServicesForUser(roles, { policies: [] }, 'LEI', 12345, [], null)
-      expect(!!output.find(service => service.heading === 'Manage prison visits')).toEqual(visible)
+      expect(!!output.find(service => service.heading === 'Social visits')).toEqual(visible)
     })
   })
 

--- a/server/services/utils/getServicesForUser.ts
+++ b/server/services/utils/getServicesForUser.ts
@@ -226,8 +226,8 @@ export default (
     },
     {
       id: 'book-a-prison-visit',
-      heading: 'Manage prison visits',
-      description: 'Book, view and cancel a prisoner’s social visits.',
+      heading: 'Social visits',
+      description: 'Book and manage social visits.',
       href: config.serviceUrls.managePrisonVisits.url,
       navEnabled: true,
       enabled: () => userHasRoles([Role.ManagePrisonVisits], roles),


### PR DESCRIPTION
This PR updates the "Manage prison visits" service name to "Social visits". This more accurately describes the service and differentiates it from the new "Official visits" service.