### PR TITLE
Update infrastructure setup

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,28 @@
 version: 2
+
+multi-ecosystem-groups:
+  infrastructure:
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+      time: "10:02"
+      timezone: "Europe/London"
+
 updates:
-  - package-ecosystem: npm
-    directory: /
+  # main dependencies
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "10:15"
+      timezone: "Europe/London"
+    cooldown:
+      default-days: 7
+      exclude:
+        - "@ministryofjustice/*"
+    groups:
+      development:
+        dependency-type: "development"
     ignore:
       - dependency-name: "@types/node"
         versions:
@@ -9,31 +30,45 @@ updates:
       - dependency-name: "applicationinsights"
         versions:
           - ">=3"
+
+  # infrastructure dependencies
+  - package-ecosystem: "docker"
+    multi-ecosystem-group: "infrastructure"
+    directory: "/"
+    patterns:
+      - "*"
     cooldown:
       default-days: 7
-      exclude:
-        - "@ministryofjustice/*"
-    schedule:
-      interval: weekly
-      day: wednesday
-    groups:
-      development:
-        dependency-type: "development"
-
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: weekly
-      day: wednesday
+  - package-ecosystem: "docker-compose"
+    multi-ecosystem-group: "infrastructure"
+    directory: "/"
+    patterns:
+      - "*"
+    cooldown:
+      default-days: 7
+  - package-ecosystem: "github-actions"
+    multi-ecosystem-group: "infrastructure"
+    directory: "/"
+    patterns:
+      - "*"
     cooldown:
       default-days: 7
       exclude:
         - "ministryofjustice/*"
-
-  - package-ecosystem: pre-commit
+  - package-ecosystem: "helm"
+    multi-ecosystem-group: "infrastructure"
+    directories:
+      - "/helm_deploy/*"
+    patterns:
+      - "*"
     cooldown:
       default-days: 7
-    directory: /
-    schedule:
-      interval: weekly
-      day: wednesday
+      exclude:
+        - "https://ministryofjustice.github.io/hmpps-helm-charts/*"
+  - package-ecosystem: "pre-commit"
+    multi-ecosystem-group: "infrastructure"
+    directory: "/"
+    patterns:
+      - "*"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/security_codeql_actions_scan.yml
+++ b/.github/workflows/security_codeql_actions_scan.yml
@@ -3,7 +3,8 @@ name: Security CodeQL actions scan
 on:
   workflow_dispatch:
   schedule:
-    - cron: "19 6 * * MON-FRI" # Every weekday
+    - cron: "19 6 * * MON-FRI"
+      timezone: "Europe/London"
 
 jobs:
   security-codeql-actions-check:

--- a/.github/workflows/security_codeql_scan.yml
+++ b/.github/workflows/security_codeql_scan.yml
@@ -3,7 +3,8 @@ name: Security CodeQL javascript/typescript scan
 on:
   workflow_dispatch:
   schedule:
-    - cron: "7 10 * * MON-FRI" # Every weekday ~10
+    - cron: "7 10 * * MON-FRI"
+      timezone: "Europe/London"
 
 jobs:
   security-codeql-check:

--- a/.github/workflows/security_npm_dependency.yml
+++ b/.github/workflows/security_npm_dependency.yml
@@ -2,7 +2,9 @@ name: Security npm dependency check
 on:
   workflow_dispatch:
   schedule:
-    - cron: "19 6 * * MON-FRI" # Every weekday
+    - cron: "19 6 * * MON-FRI"
+      timezone: "Europe/London"
+
 jobs:
   security-npm-dependency-check:
     permissions:

--- a/.github/workflows/security_snyk_scan.yml
+++ b/.github/workflows/security_snyk_scan.yml
@@ -22,5 +22,6 @@ jobs:
       slack_include_summary: true
       snyk_policy_path: '' # Optional path to a custom Snyk policy file
     secrets:
-      HMPPS_SNYK_API_KEY: ${{ secrets.HMPPS_SNYK_API_KEY }}
+      HMPPS_SNYK_CLIENT_SECRET: ${{ secrets.HMPPS_SNYK_CLIENT_SECRET }}
+      HMPPS_SNYK_CLIENT_ID: ${{ secrets.HMPPS_SNYK_CLIENT_ID }}
       HMPPS_SRE_SLACK_BOT_TOKEN: ${{ secrets.HMPPS_SRE_SLACK_BOT_TOKEN }}

--- a/.github/workflows/security_snyk_scan.yml
+++ b/.github/workflows/security_snyk_scan.yml
@@ -13,7 +13,7 @@ jobs:
       actions: read
       security-events: write
     name: Project security Snyk dependency check
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_snyk_scan.yml@v3
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_snyk_scan.yml@v2
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
       subproject: ''

--- a/.github/workflows/security_snyk_scan.yml
+++ b/.github/workflows/security_snyk_scan.yml
@@ -3,7 +3,8 @@ name: Security Snyk dependency check
 on:
   workflow_dispatch:
   schedule:
-    - cron: "34 13 * * 1-5"
+    - cron: "34 13 * * MON-FRI"
+      timezone: "Europe/London"
 
 jobs:
   security-snyk-check:
@@ -12,7 +13,7 @@ jobs:
       actions: read
       security-events: write
     name: Project security Snyk dependency check
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_snyk_scan.yml@v2
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_snyk_scan.yml@v3
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
       subproject: ''

--- a/.github/workflows/security_veracode_pipeline_scan.yml
+++ b/.github/workflows/security_veracode_pipeline_scan.yml
@@ -2,7 +2,8 @@ name: Security veracode pipeline scan
 on:
   workflow_dispatch:
   schedule:
-    - cron: "19 6 * * MON-FRI" # Every weekday
+    - cron: "19 6 * * MON-FRI"
+      timezone: "Europe/London"
 jobs:
   security-veracode-pipeline-scan:
     permissions:

--- a/.github/workflows/security_veracode_policy_scan.yml
+++ b/.github/workflows/security_veracode_policy_scan.yml
@@ -2,7 +2,8 @@ name: Security veracode policy scan
 on:
   workflow_dispatch:
   schedule:
-    - cron: "34 6 * * 1" # Every Monday
+    - cron: "34 6 * * MON"
+      timezone: "Europe/London"
 jobs:
   security-veracode-policy-check:
     permissions:

--- a/.npmrc
+++ b/.npmrc
@@ -9,7 +9,7 @@ save-exact = true
 # Fail if trying to use incorrect version of npm
 engine-strict = true
 
-# Show any output of scripts in the console 
+# Show any output of scripts in the console
 foreground-scripts = true
 
 # Wait a minimum of 7 days before allowing a package to be released, this is to allow time for any issues to be discovered and fixed before the package is released

--- a/helm_deploy/hmpps-micro-frontend-components/Chart.yaml
+++ b/helm_deploy/hmpps-micro-frontend-components/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-micro-frontend-components
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: "3.16"
+    version: "3.17"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: "1.17"

--- a/integration_tests/start-feature-test-app.sh
+++ b/integration_tests/start-feature-test-app.sh
@@ -20,7 +20,7 @@ cd hmpps-template-typescript
 # May cause issues if there's version mismatches
 grep -v 'min-release-age' .npmrc > .npmrc.tmp && mv .npmrc.tmp .npmrc
 
-npx @ministryofjustice/hmpps-connect-dps-components
+npx @ministryofjustice/hmpps-connect-dps-components@latest
 
 info_msg Building template project
 npm run build


### PR DESCRIPTION
- dependency updates for infrastructure are grouped into 1 and main dependencies are checked on weekdays
- latest HMPPS helm `generic-service` chart
- snyk now uses oauth instead of api token