### PR TITLE
Fix width variable for govuk-frontend 6.2

### DIFF
--- a/assets/scss/footer.scss
+++ b/assets/scss/footer.scss
@@ -1,7 +1,5 @@
-$govuk-page-width: 1170px;
+@import './overrides/settings';
 
-@import 'govuk-frontend/dist/govuk/settings/spacing';
-@import 'govuk-frontend/dist/govuk/helpers/spacing';
-@import 'govuk-frontend/dist/govuk/objects/width-container';
+@import 'govuk-frontend/dist/govuk/base';
 
 @import './components/footer';

--- a/assets/scss/header.scss
+++ b/assets/scss/header.scss
@@ -1,7 +1,6 @@
-$govuk-page-width: 1170px;
+@import './overrides/settings';
 
 @import 'govuk-frontend/dist/govuk/base';
-@import 'govuk-frontend/dist/govuk/objects/width-container';
 
 @import './components/external-header';
 @import './components/dps-header';

--- a/assets/scss/index.scss
+++ b/assets/scss/index.scss
@@ -1,8 +1,4 @@
-$govuk-global-styles: true;
-$path: '/assets/images/';
-
-$moj-page-width: 1170px;
-$govuk-page-width: $moj-page-width;
+@import './overrides/settings';
 
 @import 'govuk-frontend/dist/govuk/index';
 @import '@ministryofjustice/frontend/moj/all';

--- a/assets/scss/overrides/_settings.scss
+++ b/assets/scss/overrides/_settings.scss
@@ -1,0 +1,5 @@
+$govuk-global-styles: true;
+$path: '/assets/images/';
+
+$moj-page-width: 1170px;
+$govuk-page-width: $moj-page-width;


### PR DESCRIPTION
Notably, the footer component’s width was set incorrectly whereas the header was fine. This is related to the differing scss imports and their order.

Before: both components included a style for `.govuk-width-container` but this should reasonably be left to client application.

Now: neither component includes `.govuk-width-container` which is a breaking change, but probably a sensible one? DPS applications already should set the width variables themselves.