### PR TITLE
CDPS-1973: Trial typescript-based cronjob

### DIFF
--- a/esbuild/build.config.js
+++ b/esbuild/build.config.js
@@ -18,6 +18,7 @@ const getBuildConfig = () => {
       outDir: path.join(cwd, 'dist'),
       entryPoints: globSync([
         path.join(cwd, '*.ts'),
+        path.join(cwd, 'scripts/**/*.ts'),
         path.join(cwd, 'server/**/*.ts'),
         path.join(cwd, 'server/**/*.json'),
       ]).filter(file => !file.endsWith('.test.ts') && !file.endsWith('.config.ts')),

--- a/helm_deploy/hmpps-micro-frontend-components/templates/trial-ts-job.yaml
+++ b/helm_deploy/hmpps-micro-frontend-components/templates/trial-ts-job.yaml
@@ -1,0 +1,44 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: trial-ts-job
+spec:
+  schedule: "*/15 9-18 * * 1-5"
+  timeZone: Europe/London
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 5
+  successfulJobsHistoryLimit: 5
+  startingDeadlineSeconds: 600
+  suspend: {{ index .Values "suspend-trial-ts-job" }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: trial-ts-job
+              image: '{{ index .Values "generic-service" "image" "repository" }}:{{ index .Values "generic-service" "image" "tag" | default .Chart.AppVersion }}'
+              env:
+                - name: ENVIRONMENT
+                  value: '{{ index .Values "generic-service" "env" "ENVIRONMENT" }}'
+                - name: ENVIRONMENT_NAME
+                  value: '{{ index .Values "generic-service" "env" "ENVIRONMENT_NAME" }}'
+                - name: SENTRY_ENVIRONMENT
+                  value: '{{ index .Values "generic-service" "env" "SENTRY_ENVIRONMENT" }}'
+
+                - name: REDIS_HOST
+                  valueFrom:
+                    secretKeyRef:
+                      name: elasticache-redis
+                      key: primary_endpoint_address
+                - name: REDIS_AUTH_TOKEN
+                  valueFrom:
+                    secretKeyRef:
+                      name: elasticache-redis
+                      key: auth_token
+                - name: REDIS_TLS_ENABLED
+                  value: '{{ index .Values "generic-service" "env" "REDIS_TLS_ENABLED" }}'
+
+              command: ["node", "-e", "require(\"./dist/scripts/trialTsJob\").main()"]
+
+          restartPolicy: Never
+          activeDeadlineSeconds: 300

--- a/helm_deploy/hmpps-micro-frontend-components/values.yaml
+++ b/helm_deploy/hmpps-micro-frontend-components/values.yaml
@@ -1,4 +1,5 @@
----
+suspend-trial-ts-job: true
+
 generic-service:
   nameOverride: hmpps-micro-frontend-components
   productId: DPS019

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,4 +1,5 @@
 services_cronjob_schedule: "0 7-18 * * 1-5"
+suspend-trial-ts-job: false
 
 generic-service:
   replicaCount: 2

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "int-test-ui": "cypress open --e2e --browser chrome",
     "clean": "rm -rf dist test_results",
     "rebuild": "npm run clean && npm run setup && npm run build",
-    "getAppsStatus": "node -e 'require(\"./scripts/getReleaseStatus\").getData()'",
     "precommit:secrets": "gitleaks git --pre-commit --redact --staged --verbose --config .gitleaks/config.toml --gitleaks-ignore-path .gitleaks/.gitleaksignore",
     "precommit:lint": "lint-staged",
     "precommit:verify": "npm run typecheck && npm test",

--- a/scripts/trialTsJob.ts
+++ b/scripts/trialTsJob.ts
@@ -1,0 +1,76 @@
+import { inspect } from 'node:util'
+import { createClient, type RedisClientType } from 'redis'
+import superagent from 'superagent'
+
+// eslint-disable-next-line import/prefer-default-export
+export async function main() {
+  process.stderr.write('TRIAL TS JOB START\n')
+  process.stderr.write(`ENVIRONMENT=${process.env.ENVIRONMENT}\n`)
+  process.stderr.write(`ENVIRONMENT_NAME=${process.env.ENVIRONMENT_NAME}\n`)
+  process.stderr.write(`SENTRY_ENVIRONMENT=${process.env.SENTRY_ENVIRONMENT}\n`)
+
+  const redisClient = getRedisClient()
+  await ensureConnected(redisClient)
+
+  const storedData = await getStoredData(redisClient)
+  process.stdout.write(`loaded ${storedData.length} items from redis\n`)
+
+  const response = await getApplicationInfo('DPS', 'https://dps-dev.prison.service.justice.gov.uk/info')
+  process.stdout.write(inspect(response.body))
+  process.stdout.write('\n')
+
+  process.stderr.write('TRIAL TS JOB END\n')
+}
+
+function getRedisClient(): RedisClientType {
+  process.stderr.write('Creating redis client\n')
+  const host = process.env.REDIS_HOST || 'localhost'
+  const protocol = process.env.REDIS_TLS_ENABLED === 'true' ? 'rediss' : 'redis'
+  const port = parseInt(process.env.REDIS_PORT, 10) || 6379
+  return createClient({
+    url: `${protocol}://${host}:${port}`,
+    password: process.env.REDIS_AUTH_TOKEN,
+    socket: {
+      reconnectStrategy: attempts => {
+        // Exponential back off: 20ms, 40ms, 80ms..., capped to retry every 30 seconds
+        const nextDelay = Math.min(2 ** attempts * 20, 30000)
+        process.stderr.write(`Retry Redis connection attempt: ${attempts}, next attempt in: ${nextDelay}ms\n`)
+        return nextDelay
+      },
+    },
+  })
+    .on('connect', () => {
+      process.stderr.write('Redis client is connecting\n')
+    })
+    .on('ready', () => {
+      process.stderr.write('Redis client is ready for use\n')
+    })
+    .on('end', () => {
+      process.stderr.write('Redis client connection closed\n')
+    })
+    .on('error', err => {
+      process.stderr.write(`Redis error: ${err}\n`)
+    })
+}
+
+async function ensureConnected(redisClient: RedisClientType): Promise<void> {
+  if (!redisClient.isOpen) {
+    await redisClient.connect()
+  }
+}
+
+async function getStoredData(redisClient: RedisClientType): Promise<object[]> {
+  const responseString = await redisClient.get('applicationInfo')
+  process.stderr.write(`Previous stored application info: ${responseString}\n`)
+  return JSON.parse(responseString as string)
+}
+
+function getApplicationInfo(appLabel: string, url: string): superagent.Request {
+  process.stderr.write(`Calling superagent GET ${url}\n`)
+  return superagent
+    .get(url)
+    .set('Accept', 'application/json')
+    .retry(2, (_err, res) => {
+      process.stderr.write(`Received status ${res?.status} from application info request for ${appLabel}\n`)
+    })
+}


### PR DESCRIPTION
the last attempt (#570) to convert the existing cronjob to typescript failed because script couldn’t import redis for some reason.

this attempt adds a _new_ cronjob alongside to test out compilation and whether the job can make redis & superagent connections. only scheduled in `dev`