### PR TITLE
CDPS-1973: Convert cronjob script to typescript (2nd attempt)

### DIFF
--- a/helm_deploy/hmpps-micro-frontend-components/templates/services-cronjob.yaml
+++ b/helm_deploy/hmpps-micro-frontend-components/templates/services-cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: hmpps-micro-frontend-components-services
 spec:
-  schedule: "{{ .Values.services_cronjob_schedule }}"
+  schedule: '{{ .Values.services_cronjob_schedule }}'
   timeZone: Europe/London
   concurrencyPolicy: Forbid
   failedJobsHistoryLimit: 5
@@ -46,7 +46,7 @@ spec:
               - name: INFO_DISABLED_APPS
                 value: '{{ index .Values "generic-service" "env" "INFO_DISABLED_APPS" }}'
 
-              # service urls for caching info by `/scripts/getReleaseStatus.js`:
+              # service urls for caching info by `/scripts/getReleaseStatus.ts`:
 
               - name: ACTIVITIES_URL
                 value: '{{ index .Values "generic-service" "env" "ACTIVITIES_URL" }}'
@@ -87,6 +87,6 @@ spec:
               - name: ALLOCATE_PERSONAL_OFFICERS_API_URL
                 value: '{{ index .Values "generic-service" "env" "ALLOCATE_PERSONAL_OFFICERS_API_URL" }}'
 
-              command: ["node", "-e", "require(\"./scripts/getReleaseStatus\").getData()"]
+              command: ["node", "-e", "require(\"./dist/scripts/getReleaseStatus\").getData()"]
           restartPolicy: Never
           activeDeadlineSeconds: 300

--- a/helm_deploy/hmpps-micro-frontend-components/templates/services-cronjob.yaml
+++ b/helm_deploy/hmpps-micro-frontend-components/templates/services-cronjob.yaml
@@ -87,6 +87,6 @@ spec:
               - name: ALLOCATE_PERSONAL_OFFICERS_API_URL
                 value: '{{ index .Values "generic-service" "env" "ALLOCATE_PERSONAL_OFFICERS_API_URL" }}'
 
-              command: ["node", "-e", "require(\"./dist/scripts/getReleaseStatus\").getData()"]
+              command: ["node", "-e", "require(\"./dist/scripts/getReleaseStatus\").main()"]
           restartPolicy: Never
           activeDeadlineSeconds: 300

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -1,4 +1,4 @@
-services_cronjob_schedule: "0 7-18 * * 1-5"
+services_cronjob_schedule: "0 8-18 * * 1-5"
 
 generic-service:
   replicaCount: 2

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,4 +1,4 @@
-services_cronjob_schedule: "0 7-18 * * 1-5"
+services_cronjob_schedule: "0 8-18 * * 1-5"
 
 generic-service:
   replicaCount: 2

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,8 @@
         "superagent": "^10.3.0",
         "swagger-jsdoc": "^6.3.0",
         "swagger-ui-express": "^5.0.1",
-        "url-value-parser": "^2.2.0"
+        "url-value-parser": "^2.2.0",
+        "yaml": "2.9.0"
       },
       "devDependencies": {
         "@jgoz/esbuild-plugin-typecheck": "^4.0.4",
@@ -8499,7 +8500,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -16507,9 +16507,7 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "yaml": "bin.mjs"
       },

--- a/package.json
+++ b/package.json
@@ -70,7 +70,8 @@
     "superagent": "^10.3.0",
     "swagger-jsdoc": "^6.3.0",
     "swagger-ui-express": "^5.0.1",
-    "url-value-parser": "^2.2.0"
+    "url-value-parser": "^2.2.0",
+    "yaml": "2.9.0"
   },
   "devDependencies": {
     "@jgoz/esbuild-plugin-typecheck": "^4.0.4",

--- a/scripts/getReleaseStatus.d.ts
+++ b/scripts/getReleaseStatus.d.ts
@@ -1,2 +1,0 @@
-export async function getData(): Promise<void>
-export default { getData }

--- a/scripts/getReleaseStatus.js
+++ b/scripts/getReleaseStatus.js
@@ -200,6 +200,8 @@ const getData = async () => {
     : newData
 
   await cacheResponses(body, redisClient)
+
+  await redisClient.close()
   redisClient.destroy()
 }
 

--- a/scripts/getReleaseStatus.test.ts
+++ b/scripts/getReleaseStatus.test.ts
@@ -1,7 +1,10 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
 import nock from 'nock'
-import redis from 'redis'
+import redis, { type RedisClientType } from 'redis'
+import yaml from 'yaml'
 
-import { getData } from './getReleaseStatus'
+import { endpoints, getData } from './getReleaseStatus'
 
 const residentialLocationUrl = 'https://locations-inside-prison-api-dev.hmpps.service.justice.gov.uk'
 const reportingUrl = 'https://digital-prison-reporting-mi-ui-dev.hmpps.service.justice.gov.uk'
@@ -64,14 +67,13 @@ jest.mock('redis', () => {
   }
 })
 
-type RedisClient = ReturnType<(typeof redis)['createClient']>
-let mockRedisClientMock: jest.Mocked<RedisClient>
+let mockRedisClientMock: jest.MockedObjectDeep<RedisClientType>
 
 beforeAll(() => {
   jest.spyOn(console, 'log').mockImplementation(() => undefined)
   jest.spyOn(console, 'error').mockImplementation(() => undefined)
 
-  mockRedisClientMock = redis.createClient() as unknown as jest.Mocked<RedisClient>
+  mockRedisClientMock = jest.mocked(redis.createClient())
 })
 
 describe('Get release status script', () => {
@@ -297,5 +299,20 @@ describe('Get release status script', () => {
         ]),
       )
     })
+  })
+
+  it('should be set up correctly in helm chart', async () => {
+    const helmChartPath = path.join(
+      __dirname,
+      '../helm_deploy/hmpps-micro-frontend-components/templates/services-cronjob.yaml',
+    )
+    const helmChart = await fs.readFile(helmChartPath, { encoding: 'utf8' }).then(yaml.parse)
+    const { env }: { env: { name: string }[] } = helmChart.spec.jobTemplate.spec.template.spec.containers[0]
+    const helmEnvVars = new Set(env.map(item => item.name))
+
+    const scriptEnvVars = new Set(endpoints.filter(endpoint => 'urlEnv' in endpoint).map(endpoint => endpoint.urlEnv))
+
+    const missingEnvVars = scriptEnvVars.difference(helmEnvVars)
+    expect(missingEnvVars).toEqual(new Set())
   })
 })

--- a/scripts/getReleaseStatus.test.ts
+++ b/scripts/getReleaseStatus.test.ts
@@ -53,6 +53,7 @@ jest.mock('redis', () => {
     get: jest.fn().mockResolvedValue(null),
     disconnect: jest.fn().mockResolvedValue('OK'),
     connect: jest.fn().mockResolvedValue('OK'),
+    close: jest.fn(),
     destroy: jest.fn(),
     isOpen: false,
     on: jest.fn().mockReturnThis(),

--- a/scripts/getReleaseStatus.ts
+++ b/scripts/getReleaseStatus.ts
@@ -221,3 +221,17 @@ export async function getData(): Promise<void> {
   await redisClient.close()
   redisClient.destroy()
 }
+
+export function main() {
+  getData()
+    .then(() => {
+      console.info('Successfully updated active agencies')
+    })
+    .catch((error: Error) => {
+      process.exitCode = 1
+      console.error('Uncaught error', error)
+      reportError('Uncaught error', {
+        error: JSON.stringify(error),
+      })
+    })
+}

--- a/scripts/getReleaseStatus.ts
+++ b/scripts/getReleaseStatus.ts
@@ -2,7 +2,7 @@
 
 import * as Sentry from '@sentry/node'
 import superagent from 'superagent'
-import redis, { type RedisClientType } from 'redis'
+import { createClient, type RedisClientType } from 'redis'
 import { type ServiceActiveAgencies, ServiceName } from '../server/@types/activeAgencies'
 
 let reportError: (message: string, context: Record<string, string>) => void = () => {}
@@ -85,19 +85,18 @@ function getRedisClient(): RedisClientType {
   const host = process.env.REDIS_HOST || 'localhost'
   const protocol = process.env.REDIS_TLS_ENABLED === 'true' ? 'rediss' : 'redis'
   const port = parseInt(process.env.REDIS_PORT, 10) || 6379
-  return redis
-    .createClient({
-      url: `${protocol}://${host}:${port}`,
-      password: process.env.REDIS_AUTH_TOKEN,
-      socket: {
-        reconnectStrategy: attempts => {
-          // Exponential back off: 20ms, 40ms, 80ms..., capped to retry every 30 seconds
-          const nextDelay = Math.min(2 ** attempts * 20, 30000)
-          console.log(`Retry Redis connection attempt: ${attempts}, next attempt in: ${nextDelay}ms`)
-          return nextDelay
-        },
+  return createClient({
+    url: `${protocol}://${host}:${port}`,
+    password: process.env.REDIS_AUTH_TOKEN,
+    socket: {
+      reconnectStrategy: attempts => {
+        // Exponential back off: 20ms, 40ms, 80ms..., capped to retry every 30 seconds
+        const nextDelay = Math.min(2 ** attempts * 20, 30000)
+        console.log(`Retry Redis connection attempt: ${attempts}, next attempt in: ${nextDelay}ms`)
+        return nextDelay
       },
-    })
+    },
+  })
     .on('connect', () => {
       console.log('Redis client is connecting')
     })

--- a/scripts/getReleaseStatus.ts
+++ b/scripts/getReleaseStatus.ts
@@ -1,8 +1,11 @@
 /* eslint-disable no-console */
 
-const Sentry = require('@sentry/node')
+import * as Sentry from '@sentry/node'
+import superagent from 'superagent'
+import redis, { type RedisClientType } from 'redis'
+import { type ServiceActiveAgencies, ServiceName } from '../server/@types/activeAgencies'
 
-let reportError = () => {}
+let reportError: (message: string, context: Record<string, string>) => void = () => {}
 if (process.env.SENTRY_DSN) {
   Sentry.init({
     dsn: process.env.SENTRY_DSN,
@@ -22,47 +25,62 @@ if (process.env.SENTRY_DSN) {
   }
 }
 
-const superagent = require('superagent')
-const redis = require('redis')
+type Environment = 'dev' | 'preprod' | 'prod'
+export type Endpoint = { application: ServiceName } & ({ urlEnv: string } | { infoUrl: Record<Environment, string> })
 
-const endpoints = [
+/**
+ * List of services whose /info endpoint is periodically loaded and cached
+ * to get the agencies/prisons in which they are enabled.
+ *
+ * Add definitions here:
+ * - provide `urlEnv` to look up info url via site’s base url environment variable
+ * - or provide an environment-to-info-url map in `infoUrl`
+ *
+ * When using environment variables, also:
+ * - Add urls to
+ *   - `/helm_deploy/values-dev.yaml`
+ *   - `/helm_deploy/values-preprod.yaml`
+ *   - `/helm_deploy/values-prod.yaml`
+ * - Add mapping to `/helm_deploy/hmpps-micro-frontend-components/templates/services-cronjob.yaml`
+ */
+export const endpoints: Endpoint[] = [
   {
-    application: 'adjudications',
+    application: ServiceName.ADJUDICATION,
     infoUrl: {
       prod: 'https://manage-adjudications-api.hmpps.service.justice.gov.uk/info',
       preprod: 'https://manage-adjudications-api-preprod.hmpps.service.justice.gov.uk/info',
       dev: 'https://manage-adjudications-api-dev.hmpps.service.justice.gov.uk/info',
     },
   },
-  { application: 'activities', urlEnv: 'ACTIVITIES_URL' },
-  { application: 'cas2', urlEnv: 'CAS2_URL' },
-  { application: 'alerts', urlEnv: 'ALERTS_API_URL' },
-  { application: 'csipApi', urlEnv: 'CSIP_API_URL' },
-  { application: 'reporting', urlEnv: 'REPORTING_URL' },
-  { application: 'residentialLocations', urlEnv: 'RESIDENTIAL_LOCATIONS_API_URL' },
-  { application: 'learningAndWorkProgress', urlEnv: 'LEARNING_AND_WORK_PROGRESS_URL' },
-  { application: 'whereabouts', urlEnv: 'WHEREABOUTS_API_URL' },
-  { application: 'caseNotesApi', urlEnv: 'CASE_NOTES_API_URL' },
-  { application: 'prepareSomeoneForReleaseUi', urlEnv: 'PREPARE_SOMEONE_FOR_RELEASE_URL' },
-  { application: 'cemo', urlEnv: 'CEMO_URL' },
-  { application: 'manageApplications', urlEnv: 'MANAGE_APPLICATIONS_URL' },
-  { application: 'allocateKeyWorkers', urlEnv: 'ALLOCATE_KEY_WORKERS_API_URL' },
-  { application: 'allocatePersonalOfficers', urlEnv: 'ALLOCATE_PERSONAL_OFFICERS_API_URL' },
-  { application: 'externalMovements', urlEnv: 'EXTERNAL_MOVEMENTS_API_URL' },
-  { application: 'officialVisitsApi', urlEnv: 'OFFICIAL_VISITS_API_URL' },
-  { application: 'courtAppearanceScheduler', urlEnv: 'COURT_APPEARANCE_SCHEDULER_API_URL' },
+  { application: ServiceName.ACTIVITIES, urlEnv: 'ACTIVITIES_URL' },
+  { application: ServiceName.CAS2, urlEnv: 'CAS2_URL' },
+  { application: ServiceName.ALERTS, urlEnv: 'ALERTS_API_URL' },
+  { application: ServiceName.CSIP, urlEnv: 'CSIP_API_URL' },
+  { application: ServiceName.REPORTING, urlEnv: 'REPORTING_URL' },
+  { application: ServiceName.RESIDENTIAL_LOCATIONS, urlEnv: 'RESIDENTIAL_LOCATIONS_API_URL' },
+  { application: ServiceName.LEARNING_AND_WORK_PROGRESS, urlEnv: 'LEARNING_AND_WORK_PROGRESS_URL' },
+  { application: ServiceName.WHEREABOUTS, urlEnv: 'WHEREABOUTS_API_URL' },
+  { application: ServiceName.CASE_NOTES, urlEnv: 'CASE_NOTES_API_URL' },
+  { application: ServiceName.PREPARE_SOMEONE_FOR_RELEASE, urlEnv: 'PREPARE_SOMEONE_FOR_RELEASE_URL' },
+  { application: ServiceName.CEMO, urlEnv: 'CEMO_URL' },
+  { application: ServiceName.MANAGE_APPLICATIONS, urlEnv: 'MANAGE_APPLICATIONS_URL' },
+  { application: ServiceName.ALLOCATE_KEY_WORKERS, urlEnv: 'ALLOCATE_KEY_WORKERS_API_URL' },
+  { application: ServiceName.ALLOCATE_PERSONAL_OFFICERS, urlEnv: 'ALLOCATE_PERSONAL_OFFICERS_API_URL' },
+  { application: ServiceName.EXTERNAL_MOVEMENTS, urlEnv: 'EXTERNAL_MOVEMENTS_API_URL' },
+  { application: ServiceName.OFFICIAL_VISITS_API, urlEnv: 'OFFICIAL_VISITS_API_URL' },
+  { application: ServiceName.COURT_APPEARANCE_SCHEDULER, urlEnv: 'COURT_APPEARANCE_SCHEDULER_API_URL' },
 ]
 
-function getApplicationInfo(appLabel, url) {
+function getApplicationInfo(appLabel: ServiceName, url: string): superagent.Request {
   return superagent
     .get(url)
     .set('Accept', 'application/json')
-    .retry(2, (err, res) => {
+    .retry(2, (_err, res) => {
       console.log(`Received status ${res?.status} from application info request for ${appLabel}`)
     })
 }
 
-async function getRedisClient() {
+function getRedisClient(): RedisClientType {
   console.log('Creating redis client')
   const host = process.env.REDIS_HOST || 'localhost'
   const protocol = process.env.REDIS_TLS_ENABLED === 'true' ? 'rediss' : 'redis'
@@ -94,34 +112,32 @@ async function getRedisClient() {
     })
 }
 
-async function ensureConnected(redisClient) {
+async function ensureConnected(redisClient: RedisClientType): Promise<void> {
   if (!redisClient.isOpen) {
     await redisClient.connect()
   }
 }
 
-async function cacheResponses(body, redisClient) {
-  const resp = await redisClient.set('applicationInfo', JSON.stringify(body))
-
+async function cacheResponses(body: ServiceActiveAgencies[], redisClient: RedisClientType): Promise<void> {
+  await redisClient.set('applicationInfo', JSON.stringify(body))
   console.log('Successfully cached application info', body)
-  return resp
 }
 
-async function getStoredData(redisClient) {
+async function getStoredData(redisClient: RedisClientType): Promise<ServiceActiveAgencies[]> {
   const responseString = await redisClient.get('applicationInfo')
   console.log(`Previous stored application info: ${responseString}`)
-  return JSON.parse(responseString)
+  return JSON.parse(responseString as string)
 }
 
-function getUrlForApp(appData) {
-  if (appData.urlEnv) {
+function getUrlForApp(appData: Endpoint): string | undefined {
+  if ('urlEnv' in appData) {
     return process.env[appData.urlEnv] ? `${process.env[appData.urlEnv]}/info` : undefined
   }
-  return appData.infoUrl[process.env.ENVIRONMENT]
+  return appData.infoUrl[process.env.ENVIRONMENT as Environment]
 }
 
-const getData = async () => {
-  const redisClient = await getRedisClient()
+export async function getData(): Promise<void> {
+  const redisClient = getRedisClient()
   await ensureConnected(redisClient)
 
   const storedData = await getStoredData(redisClient)
@@ -148,7 +164,7 @@ const getData = async () => {
       .filter(Boolean),
   )
 
-  const newData = responses
+  const newData: ServiceActiveAgencies[] = responses
     .map(response => {
       if (response.status !== 'fulfilled') {
         console.error('Failed to get application info', response.reason)
@@ -160,10 +176,12 @@ const getData = async () => {
       const { body, request } = response.value
 
       const applicationName = endpoints.find(
-        app => request?.url === (app.urlEnv ? `${process.env[app.urlEnv]}/info` : app.infoUrl[process.env.ENVIRONMENT]),
+        app =>
+          request?.url ===
+          ('urlEnv' in app ? `${process.env[app.urlEnv]}/info` : app.infoUrl[process.env.ENVIRONMENT as Environment]),
       )?.application
       if (!applicationName) {
-        console.error('Cannot match response to application')
+        console.error(`Cannot match response to application (${request?.url})`)
         reportError('Cannot match response to application', {
           request: request?.url,
         })
@@ -204,5 +222,3 @@ const getData = async () => {
   await redisClient.close()
   redisClient.destroy()
 }
-
-module.exports = { getData }

--- a/server/@types/activeAgencies.ts
+++ b/server/@types/activeAgencies.ts
@@ -1,3 +1,7 @@
+/**
+ * List of services
+ * Mainly for mapping in a cache which agencies/prisons they are active in
+ */
 export enum ServiceName {
   ADJUDICATION = 'adjudications',
   ACTIVITIES = 'activities',
@@ -20,6 +24,10 @@ export enum ServiceName {
   COURT_APPEARANCE_SCHEDULER = 'courtAppearanceScheduler',
 }
 
+/**
+ * Used to map services to agencies/prisons where they are active
+ * NB: `***` is a special value indicating *everywhere*
+ */
 export interface ServiceActiveAgencies {
   app: ServiceName
   activeAgencies: string[]


### PR DESCRIPTION
First attempt (#570) had issues:
```
> node -e 'require("./dist/scripts/getReleaseStatus").getData()'

Creating redis client
This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). The promise rejected with the reason:
TypeError: Cannot read properties of undefined (reading 'createClient')
    at getRedisClient (/app/dist/scripts/getReleaseStatus.js:94:31)
    at Object.getData (/app/dist/scripts/getReleaseStatus.js:135:23)
    at [eval]:1:44
    at runScriptInThisContext (node:internal/vm:219:10)
    at node:internal/process/execution:451:12
    at [eval]-wrapper:6:24
    at runScriptInContext (node:internal/process/execution:449:60)
    at evalFunction (node:internal/process/execution:283:30)
    at evalTypeScript (node:internal/process/execution:295:3)
    at node:internal/main/eval_string:71:3
```

But a trial typescript job (#614) did successfully run (connecting to redis and calling superagent) so this should totally be possible :)