### PR TITLE
 CDPS-1973: Fix cronjob

### DIFF
--- a/scripts/getReleaseStatus.test.ts
+++ b/scripts/getReleaseStatus.test.ts
@@ -57,7 +57,6 @@ jest.mock('redis', () => {
     disconnect: jest.fn().mockResolvedValue('OK'),
     connect: jest.fn().mockResolvedValue('OK'),
     close: jest.fn(),
-    destroy: jest.fn(),
     isOpen: false,
     on: jest.fn().mockReturnThis(),
   }

--- a/scripts/getReleaseStatus.ts
+++ b/scripts/getReleaseStatus.ts
@@ -219,7 +219,6 @@ export async function getData(): Promise<void> {
   await cacheResponses(body, redisClient)
 
   await redisClient.close()
-  redisClient.destroy()
 }
 
 export function main() {


### PR DESCRIPTION
fix for #616: cannot destroy a redis client with a closed connection. cronjob logs:

```
…
Redis client connection closed
Uncaught error ClientClosedError: The client is closed
    at RedisSocket.destroy (/app/node_modules/@redis/client/dist/lib/client/socket.js:340:19)
    at Class.destroy (/app/node_modules/@redis/client/dist/lib/client/index.js:1151:28)
    at getData (/app/dist/scripts/getReleaseStatus.js:193:15)
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
```